### PR TITLE
Added splitting and control point-based approximate_inverse_evaluate for all patch types

### DIFF
--- a/include/nanospline/BSpline.h
+++ b/include/nanospline/BSpline.h
@@ -14,6 +14,7 @@ namespace nanospline {
 template<typename _Scalar, int _dim=3, int _degree=3, bool _generic=_degree<0 >
 class BSpline : public BSplineBase<_Scalar, _dim, _degree, _generic> {
     public:
+        using ThisType = BSpline<_Scalar, _dim, _degree, false>;
         using Base = BSplineBase<_Scalar, _dim, _degree, _generic>;
         using Scalar = typename Base::Scalar;
         using Point = typename Base::Point;
@@ -297,6 +298,73 @@ class BSpline : public BSplineBase<_Scalar, _dim, _degree, _generic> {
             return res;
         }
 
+    /*std::vector<ThisType> split(Scalar t) {
+        //using ThisType = BSpline<Scalar, dim, degree, generic>;
+        if(!in_domain(t)) {
+            throw invalid_setting_error("Parameter not inside of the domain.");
+        }
+        if (t == Base::get_domain_lower_bound()) {
+            return std::vector<ThisType>{*this};
+        }
+        if (t == Base::get_domain_upper_bound()) {
+            return std::vector<ThisType>{*this};
+        }
+
+        const auto d = Base::get_degree();
+        {
+            const auto& knots = Base::get_knots();
+            const int k = Base::locate_span(t);
+            const int s = (t == knots[k]) ? Base::get_multiplicity(k) : 0;
+
+            if (d > s) {
+                Base::insert_knot(t, d - s);
+            }
+        }
+
+        const auto& ctrl_pts = Base::get_control_points();
+        const int n = static_cast<int>(ctrl_pts.rows()-1);
+        const auto& knots = Base::get_knots();
+        const int m = static_cast<int>(knots.rows()-1);
+        const int k = Base::locate_span(t);
+
+        typename ThisType::ControlPoints ctrl_pts_1(k-d+1, _dim);
+        ctrl_pts_1 = ctrl_pts.topRows(k-d+1);
+
+        typename ThisType::ControlPoints ctrl_pts_2(n-k+d+1, _dim);
+        ctrl_pts_2 = ctrl_pts.bottomRows(n-k+d+1);
+
+        typename ThisType::KnotVector knots_1(k+2,1);
+        knots_1.segment(0, k+1) = knots.segment(0, k+1);
+        knots_1[k+1] = knots_1[k];
+
+        typename ThisType::KnotVector knots_2(m-k+d+1);
+        knots_2.segment(1, m-k+d) = knots.segment(k-d+1, m-k+d);
+        knots_2[0] = knots_2[1];
+
+        std::vector<ThisType> results(2);
+        results[0].set_control_points(std::move(ctrl_pts_1));
+        results[1].set_control_points(std::move(ctrl_pts_2));
+        results[0].set_knots(std::move(knots_1));
+        results[1].set_knots(std::move(knots_2));
+
+        return results;
+    }*/
+
+
+        
+        /**
+         * Extract a subcurve in range [t0, t1].
+         */
+        ThisType subcurve(Scalar t0, Scalar t1) const {
+            if (t0 > t1) {
+                throw invalid_setting_error("t0 must be smaller than t1");
+            }
+            if (t0 < 0 || t0 > 1 || t1 < 0 || t1 > 1) {
+                throw invalid_setting_error("Invalid range");
+            }
+            return split(t0)[1].split(t1)[0];
+        }
+
     public:
         std::tuple<std::vector<Bezier<Scalar, _dim, _degree, _generic>>, std::vector<Scalar>>
         convert_to_Bezier() const {
@@ -396,11 +464,12 @@ class BSpline : public BSplineBase<_Scalar, _dim, _degree, _generic> {
             for (int r=1; r<=p; r++) {
                 Scalar t = blossom_vector(r - 1);
                 for (int j=p; j>=r; j--) {
+                    int index = j+k;
                     const Scalar diff =
-                        Base::m_knots[j+1+k-r] - Base::m_knots[j+k-p];
+                        Base::m_knots[index+1-r] - Base::m_knots[index-p];
                     Scalar alpha = 0.0;
                     if (diff > 0) {
-                        alpha = (t - Base::m_knots[j+k-p]) / diff;
+                        alpha = (t - Base::m_knots[index-p]) / diff;
                     }
 
                     ctrl_pts.row(j) = (1.0-alpha) * ctrl_pts.row(j-1) +

--- a/include/nanospline/BSpline.h
+++ b/include/nanospline/BSpline.h
@@ -75,7 +75,7 @@ class BSpline : public BSplineBase<_Scalar, _dim, _degree, _generic> {
 
         void get_derivative_coefficients(int curve_degree, int knot_span,
                                          ControlPoints &control_pts) const {
-          int num_control_points = curve_degree + 1;
+          int num_control_points = curve_degree + 1; // TODO is this right?
           for (int i = 0; i < num_control_points; i++) {
             int index = i + knot_span + 1;
 

--- a/include/nanospline/BSpline.h
+++ b/include/nanospline/BSpline.h
@@ -8,9 +8,7 @@
 #include <nanospline/Exceptions.h>
 #include <nanospline/BSplineBase.h>
 #include <nanospline/Bezier.h>
-#include <iostream>
-using std::cout;
-using std::endl;
+
 namespace nanospline {
 
 template<typename _Scalar, int _dim=3, int _degree=3, bool _generic=_degree<0 >
@@ -300,60 +298,6 @@ class BSpline : public BSplineBase<_Scalar, _dim, _degree, _generic> {
             return res;
         }
 
-    /*std::vector<ThisType> split(Scalar t) {
-        //using ThisType = BSpline<Scalar, dim, degree, generic>;
-        if(!in_domain(t)) {
-            throw invalid_setting_error("Parameter not inside of the domain.");
-        }
-        if (t == Base::get_domain_lower_bound()) {
-            return std::vector<ThisType>{*this};
-        }
-        if (t == Base::get_domain_upper_bound()) {
-            return std::vector<ThisType>{*this};
-        }
-
-        const auto d = Base::get_degree();
-        {
-            const auto& knots = Base::get_knots();
-            const int k = Base::locate_span(t);
-            const int s = (t == knots[k]) ? Base::get_multiplicity(k) : 0;
-
-            if (d > s) {
-                Base::insert_knot(t, d - s);
-            }
-        }
-
-        const auto& ctrl_pts = Base::get_control_points();
-        const int n = static_cast<int>(ctrl_pts.rows()-1);
-        const auto& knots = Base::get_knots();
-        const int m = static_cast<int>(knots.rows()-1);
-        const int k = Base::locate_span(t);
-
-        typename ThisType::ControlPoints ctrl_pts_1(k-d+1, _dim);
-        ctrl_pts_1 = ctrl_pts.topRows(k-d+1);
-
-        typename ThisType::ControlPoints ctrl_pts_2(n-k+d+1, _dim);
-        ctrl_pts_2 = ctrl_pts.bottomRows(n-k+d+1);
-
-        typename ThisType::KnotVector knots_1(k+2,1);
-        knots_1.segment(0, k+1) = knots.segment(0, k+1);
-        knots_1[k+1] = knots_1[k];
-
-        typename ThisType::KnotVector knots_2(m-k+d+1);
-        knots_2.segment(1, m-k+d) = knots.segment(k-d+1, m-k+d);
-        knots_2[0] = knots_2[1];
-
-        std::vector<ThisType> results(2);
-        results[0].set_control_points(std::move(ctrl_pts_1));
-        results[1].set_control_points(std::move(ctrl_pts_2));
-        results[0].set_knots(std::move(knots_1));
-        results[1].set_knots(std::move(knots_2));
-
-        return results;
-    }*/
-
-
-        
         /**
          * Extract a subcurve in range [t0, t1].
          */

--- a/include/nanospline/BSpline.h
+++ b/include/nanospline/BSpline.h
@@ -8,7 +8,9 @@
 #include <nanospline/Exceptions.h>
 #include <nanospline/BSplineBase.h>
 #include <nanospline/Bezier.h>
-
+#include <iostream>
+using std::cout;
+using std::endl;
 namespace nanospline {
 
 template<typename _Scalar, int _dim=3, int _degree=3, bool _generic=_degree<0 >

--- a/include/nanospline/BSplineBase.h
+++ b/include/nanospline/BSplineBase.h
@@ -330,7 +330,7 @@ class BSplineBase : public CurveBase<_Scalar, _dim> {
                     m_knots.rows() - m_control_points.rows() - 1);
         }
 
-        bool in_domain(Scalar t) const {
+        bool in_domain(Scalar t) const override {
             constexpr Scalar eps = std::numeric_limits<Scalar>::epsilon();
             const int p = get_degree();
             const int num_knots = static_cast<int>(m_knots.rows());
@@ -339,12 +339,12 @@ class BSplineBase : public CurveBase<_Scalar, _dim> {
             return (t >= t_min - eps) && (t <= t_max + eps);
         }
 
-        Scalar get_domain_lower_bound() const {
+        Scalar get_domain_lower_bound() const override {
             const int p = get_degree();
             return m_knots[p];
         }
 
-        Scalar get_domain_upper_bound() const {
+        Scalar get_domain_upper_bound() const override {
             const int p = get_degree();
             const int num_knots = static_cast<int>(m_knots.rows());
             return m_knots[num_knots-p-1];

--- a/include/nanospline/BSplineBase.h
+++ b/include/nanospline/BSplineBase.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Eigen/Core>
-#include <iostream>
 #include <limits>
 
 #include <nanospline/CurveBase.h>

--- a/include/nanospline/BSplinePatch.h
+++ b/include/nanospline/BSplinePatch.h
@@ -2,6 +2,12 @@
 
 #include <nanospline/PatchBase.h>
 #include <nanospline/BSpline.h>
+#include <nanospline/split.h>
+
+#include <iostream>
+#include <vector>
+using std::cout;
+using std::endl;
 
 namespace nanospline {
 
@@ -13,6 +19,7 @@ class BSplinePatch final : public PatchBase<_Scalar, _dim> {
         static_assert(_dim > 0, "Dimension must be positive.");
 
         using Base = PatchBase<_Scalar, _dim>;
+        using ThisType = BSplinePatch<_Scalar, _dim, _degree_u, _degree_v>;
         using Scalar = typename Base::Scalar;
         using Point = typename Base::Point;
         using ControlGrid = typename Base::ControlGrid;
@@ -102,17 +109,26 @@ class BSplinePatch final : public PatchBase<_Scalar, _dim> {
         }
 
         Scalar get_u_upper_bound() const override {
-            const auto num_knots = static_cast<int>(m_knots_u.rows());
+            const auto num_knots = get_num_knots_u();
             const auto degree_u = Base::get_degree_u();
             return m_knots_u[num_knots-degree_u-1];
         }
 
         Scalar get_v_upper_bound() const override {
-            const auto num_knots = static_cast<int>(m_knots_v.rows());
+            const auto num_knots = get_num_knots_v();
             const auto degree_v = Base::get_degree_v();
             return m_knots_v[num_knots-degree_v-1];
         }
+    private:
+        // Hopefully we won't have more than 2 billion knots...
+        // If so this will break.
+        int get_num_knots_u() const {
+            return static_cast<int>(m_knots_u.rows());
+        }
 
+        int get_num_knots_v() const {
+            return static_cast<int>(m_knots_v.rows());
+        }
 
     public:
         const KnotVector& get_knots_u() const {
@@ -144,24 +160,14 @@ class BSplinePatch final : public PatchBase<_Scalar, _dim> {
         }
 
         IsoCurveU compute_iso_curve_u(Scalar v) const {
-            const auto num_v_knots = m_knots_v.size();
-            const auto num_u_knots = m_knots_u.size();
-            const int degree_u = Base::get_degree_u();
-            const int degree_v = Base::get_degree_v();
 
             typename IsoCurveU::ControlPoints control_points_u(
-                    num_u_knots-degree_u-1, _dim);
-            for (int i=0; i<num_u_knots-degree_u-1; i++) {
-                typename IsoCurveV::ControlPoints control_points_v(
-                        num_v_knots-degree_v-1, _dim);
-                for (int j=0; j<num_v_knots-degree_v-1; j++) {
-                    control_points_v.row(j) = get_control_point(i, j);
-                }
-
-                IsoCurveV iso_curve_v;
-                iso_curve_v.set_control_points(std::move(control_points_v));
-                iso_curve_v.set_knots(m_knots_v);
-                control_points_u.row(i) = iso_curve_v.evaluate(v);
+                    num_control_points_u(),_dim);
+            
+            std::vector<IsoCurveV> iso_curves_v = get_all_iso_curves_v();
+            for (int i=0; i<num_control_points_u(); i++) {
+                IsoCurveV iso_curve = iso_curves_v[i];
+                control_points_u.row(i) = iso_curve.evaluate(v);
             }
 
             IsoCurveU iso_curve_u;
@@ -172,23 +178,14 @@ class BSplinePatch final : public PatchBase<_Scalar, _dim> {
 
         IsoCurveV compute_iso_curve_v(Scalar u) const {
             const auto num_v_knots = m_knots_v.size();
-            const auto num_u_knots = m_knots_u.size();
-            const int degree_u = Base::get_degree_u();
             const int degree_v = Base::get_degree_v();
 
             typename IsoCurveV::ControlPoints control_points_v(
                     num_v_knots-degree_v-1, _dim);
+            std::vector<IsoCurveU> iso_curves_u = get_all_iso_curves_u();
             for (int j=0; j<num_v_knots-degree_v-1; j++) {
-                typename IsoCurveU::ControlPoints control_points_u(
-                        num_u_knots-degree_u-1, _dim);
-                for (int i=0; i<num_u_knots-degree_u-1; i++) {
-                    control_points_u.row(i) = get_control_point(i, j);
-                }
-
-                IsoCurveU iso_curve_u;
-                iso_curve_u.set_control_points(std::move(control_points_u));
-                iso_curve_u.set_knots(m_knots_u);
-                control_points_v.row(j) = iso_curve_u.evaluate(u);
+                IsoCurveU iso_curve = iso_curves_u[j];
+                control_points_v.row(j) = iso_curve.evaluate(u);
             }
 
             IsoCurveV iso_curve_v;
@@ -198,8 +195,8 @@ class BSplinePatch final : public PatchBase<_Scalar, _dim> {
         }
 
         BSplinePatch<_Scalar, _dim, -1, -1> compute_du_patch() const {
-            const int num_u_knots = static_cast<int>(m_knots_u.size());
-            const int num_v_knots = static_cast<int>(m_knots_v.size());
+            const int num_u_knots = get_num_knots_u();
+            const int num_v_knots = get_num_knots_v();
             const int degree_u = Base::get_degree_u();
             const int degree_v = Base::get_degree_v();
 
@@ -228,8 +225,8 @@ class BSplinePatch final : public PatchBase<_Scalar, _dim> {
         }
 
         BSplinePatch<_Scalar, _dim, -1, -1> compute_dv_patch() const {
-            const int num_u_knots = static_cast<int>(m_knots_u.size());
-            const int num_v_knots = static_cast<int>(m_knots_v.size());
+            const int num_u_knots = get_num_knots_u();
+            const int num_v_knots = get_num_knots_v();
             const int degree_u = Base::get_degree_u();
             const int degree_v = Base::get_degree_v();
 
@@ -262,16 +259,287 @@ class BSplinePatch final : public PatchBase<_Scalar, _dim> {
         }
 
 
-    protected:
+
         Point get_control_point(int ui, int vj) const {
-            const auto degree_v = Base::get_degree_v();
-            const auto row_size = m_knots_v.size() - degree_v - 1;
-            return Base::m_control_grid.row(ui*row_size + vj);
+            //const auto degree_v = Base::get_degree_v();
+            //const auto row_size = m_knots_v.size() - degree_v - 1;
+            //return Base::m_control_grid.row(ui*row_size + vj);
+            return Base::m_control_grid.row( control_point_linear_index(ui,vj));
         }
 
+        int num_control_points_u() const{
+            const auto num_u_knots = get_num_knots_u();
+            const int degree_u = Base::get_degree_u();
+            return num_u_knots - degree_u - 1;
+        }
+        
+        int num_control_points_v() const{
+            const int num_v_knots = get_num_knots_v();
+            const int degree_v = Base::get_degree_v();
+            return num_v_knots - degree_v - 1;
+        }
     protected:
         KnotVector m_knots_u;
         KnotVector m_knots_v;
+    private: 
+        // Translate (i,j) control point indexing into a linear index. Note that
+        // control points are ordered in v-major order
+        int control_point_linear_index(int i, int j) const {
+            //const auto degree_v = Base::get_degree_v();
+            return i*(num_control_points_v()) + j;
+        }
+        // Translate (i,j) control point indexing into a linear index. Note that
+        // control points are ordered in v-major order
+        //int control_point_linear_index(int i, int j) const {
+        //    return i*(_degree_v+1) + j;
+        //}
+        
+        // Construct the implicit isocurves determined by each rows of control points
+        // i.e. fixed values of v. This copies these rows into
+        // individual matrices of control points and returns the resulting
+        // curves
+        std::vector<IsoCurveU> get_all_iso_curves_u() const {
+            const int num_control_pts_u = num_control_points_u();
+            const int num_control_pts_v = num_control_points_v();
+
+            typename IsoCurveV::ControlPoints control_points_v(
+                    num_control_pts_v, _dim);
+            
+            std::vector<IsoCurveU> iso_curves;
+            for (int vj = 0; vj < num_control_pts_v; vj++) {
+              typename IsoCurveU::ControlPoints control_points_u(
+                  num_control_pts_u, _dim);
+              for (int ui = 0; ui < num_control_pts_u; ui++) {
+                control_points_u.row(ui) = get_control_point(ui, vj);
+              }
+
+              IsoCurveU iso_curve_u;
+              iso_curve_u.set_control_points(std::move(control_points_u));
+              iso_curve_u.set_knots(m_knots_u);
+              iso_curves.push_back(iso_curve_u);
+            }
+            return iso_curves;
+        }
+        // Construct the implicit isocurves determined by each column of control points
+        // i.e. fixed values of u. This copies these columns into
+        // individual matrices of control points and returns the resulting
+        // curves
+        std::vector<IsoCurveV> get_all_iso_curves_v() const {
+            const int num_control_pts_u = num_control_points_u();
+            const int num_control_pts_v = num_control_points_v();
+
+            typename IsoCurveU::ControlPoints control_points_u(
+                    num_control_pts_u, _dim);
+            std::vector<IsoCurveV> iso_curves;
+            for (int ui = 0; ui < num_control_pts_u; ui++) {
+
+              typename IsoCurveV::ControlPoints control_points_v(
+                  num_control_pts_v, _dim);
+
+              for (int vj = 0; vj < num_control_pts_v; vj++) {
+                control_points_v.row(vj) = get_control_point(ui, vj);
+              }
+
+              IsoCurveV iso_curve_v;
+              iso_curve_v.set_control_points(std::move(control_points_v));
+              iso_curve_v.set_knots(m_knots_v);
+              iso_curves.push_back(iso_curve_v);
+            }
+            return iso_curves;
+        }
+        
+    public:
+        // Split a patch into two patches along the vertical line at u
+        std::vector<ThisType> split_u(Scalar u) {
+            if(!this->in_domain_u(u)) {
+                throw invalid_setting_error("Parameter not inside of the domain.");
+            }
+          if (this->is_endpoint_u(u)){ // no split required
+              return std::vector<ThisType>{*this};
+          }
+          
+          const int num_split_patches = 2; // splitting one patch into two
+          std::vector<IsoCurveU> iso_curves_u = get_all_iso_curves_u();
+
+          // Initialize control grids of final split patches
+          std::vector<ControlGrid> split_control_pts_u(num_split_patches, 
+                  ControlGrid(this->num_control_points(), _dim));
+
+          KnotVector split_knots_less_than_u;
+          KnotVector split_knots_greater_than_u;
+          KnotVector split_knots_v = get_knots_v(); // v-knots are the same
+          for (int vj = 0; vj < num_control_points_v(); vj++) {
+            // split each isocurve
+            IsoCurveU iso_curve = iso_curves_u[vj];
+            std::vector<IsoCurveU> split_iso_curves = nanospline::split(iso_curve, u);
+            if (vj == 0) {
+              // all split curves have the same knot sequence, just grab one
+              // of them
+              split_knots_less_than_u = split_iso_curves[0].get_knots();
+              split_knots_greater_than_u = split_iso_curves[1].get_knots();
+            }
+            // Copy control points of each split curve to its proper place in
+            // the final control grid
+            for (int ci = 0; ci < num_split_patches; ci++) {
+              const auto &ctrl_pts = split_iso_curves[ci].get_control_points();
+
+              for (int ui = 0; ui < num_control_points_u(); ui++) {
+                int index = control_point_linear_index(ui, vj);
+                split_control_pts_u[ci].row(index) = ctrl_pts.row(ui);
+              }
+            }
+          }
+
+          // Initialize split patches with results
+          ThisType patch_less_than_u;
+          ThisType patch_greater_than_u;
+          patch_less_than_u.set_control_grid(split_control_pts_u[0]);
+          patch_less_than_u.set_knots_u(split_knots_less_than_u);
+          patch_less_than_u.set_knots_v(split_knots_v);
+
+          patch_greater_than_u.set_control_grid(split_control_pts_u[1]);
+          patch_greater_than_u.set_knots_u(split_knots_greater_than_u);
+          patch_greater_than_u.set_knots_v(split_knots_v);
+
+          return {patch_less_than_u, patch_greater_than_u};
+        }
+        std::vector<ThisType> split_v(Scalar v) {
+            if(!this->in_domain_v(v)) {
+                throw invalid_setting_error("Parameter not inside of the domain.");
+            }
+          if (this->is_endpoint_v(v)){ // no split required
+              return std::vector<ThisType>{*this};
+          }
+
+          const int num_split_patches = 2; // splitting one patch into two
+          std::vector<IsoCurveV> iso_curves_v = get_all_iso_curves_v();
+
+          std::vector<ControlGrid> split_control_pts_v(num_split_patches, 
+                  ControlGrid(this->num_control_points(), _dim));
+
+          KnotVector split_knots_less_than_v;
+          KnotVector split_knots_greater_than_v;
+          KnotVector split_knots_u = get_knots_u(); // u-knots are the same
+          for (int ui = 0; ui < num_control_points_u(); ui++) {
+            // split each isocurve
+            IsoCurveV iso_curve = iso_curves_v[ui];
+            std::vector<IsoCurveV> split_iso_curves = nanospline::split(iso_curve, v);
+            if (ui == 0) {
+              // all split curves have the same knot sequence, just grab one
+              // of them
+              split_knots_less_than_v = split_iso_curves[0].get_knots();
+              split_knots_greater_than_v = split_iso_curves[1].get_knots();
+            }
+
+            // Copy control points of each split curve to its proper place in
+            // the final control grid
+            for (int ci = 0; ci < num_split_patches; ci++) {
+              auto ctrl_pts = split_iso_curves[ci].get_control_points();
+
+              for (int vj = 0; vj < num_control_points_v(); vj++) {
+                int index = control_point_linear_index(ui, vj);
+                split_control_pts_v[ci].row(index) = ctrl_pts.row(vj);
+              }
+            }
+          }
+
+          // Initialize split patches with results
+          ThisType patch_less_than_v;
+          ThisType patch_greater_than_v;
+          patch_less_than_v.set_control_grid(split_control_pts_v[0]);
+          patch_less_than_v.set_knots_u(split_knots_u);
+          patch_less_than_v.set_knots_v(split_knots_less_than_v);
+
+          patch_greater_than_v.set_control_grid(split_control_pts_v[1]);
+          patch_greater_than_v.set_knots_u(split_knots_u);
+          patch_greater_than_v.set_knots_v(split_knots_greater_than_v);
+
+          return {patch_less_than_v, patch_greater_than_v};
+        }
+
+        std::vector<ThisType> split(Scalar u, Scalar v) {
+          if (!this->in_domain(u, v)) {
+            throw invalid_setting_error("Parameter not inside of the domain.");
+          }
+          if (this->is_endpoint_u(u) &&
+              this->is_endpoint_v(v)) { // no splitting required
+            return std::vector<ThisType>{*this};
+
+          } else if (this->is_endpoint_u(u)) { // no need to split along u
+            return split_v(v);
+
+          } else if (this->is_endpoint_v(v)) { // no need to split along v
+            return split_u(u);
+
+          } else {
+            // 1. split in u direction
+            std::vector<ThisType> split_patches = split_u(u);
+            ThisType less_than_u = split_patches[0];
+            ThisType greater_than_u = split_patches[1];
+
+            // 2. Split each subpatch patch at v
+            std::vector<ThisType> split_patches_less_than_u =
+                less_than_u.split_v(v);
+
+            std::vector<ThisType> split_patches_greater_than_u =
+                greater_than_u.split_v(v);
+
+            // 3. Reorder. The patch is split into 4 patches returned in the
+            // following order:
+            //
+            //   |-----------|
+            //   |  1  |  3  |
+            // ^ |-----*-----| *= split point (u,v)
+            // | |  0  |  2  |
+            // v |-----------|
+            //    u ->
+
+            ThisType less_than_u_less_than_v = split_patches_less_than_u[0];
+            ThisType less_than_u_greater_than_v = split_patches_less_than_u[1];
+            ThisType greater_than_u_less_than_v =
+                split_patches_greater_than_u[0];
+            ThisType greater_than_u_greater_than_v =
+                split_patches_greater_than_u[1];
+
+            return {less_than_u_less_than_v, less_than_u_greater_than_v,
+                    greater_than_u_less_than_v, greater_than_u_greater_than_v};
+          }
+        }
+
+        std::vector<ThisType> subpatch(const ThisType &patch, Scalar u_min,
+                                       Scalar u_max, Scalar v_min,
+                                       Scalar v_max) {
+          if (u_min > u_max) {
+            throw invalid_setting_error("u_min must be smaller than u_max");
+          }
+          if (u_min < 0 || u_min > 1 || u_max < 0 || u_max > 1) {
+            throw invalid_setting_error("Invalid range in subcurve: u");
+          }
+          if (v_min > v_max) {
+            throw invalid_setting_error("v_min must be smaller than v_max");
+          }
+          if (v_min < 0 || v_min > 1 || v_max < 0 || v_max > 1) {
+            throw invalid_setting_error("Invalid range in subcurve: v");
+          } 
+
+          // TODO add domain handling to reduce computation
+        
+          // 1. Split patch in u direction at u_min; take the patch on >= u_min
+          ThisType greater_than_umin = patch.split_u(u_min)[1];
+
+          // 2. Split patch on >= u_min at u_max in u dir; take the patch <=
+          // u_max
+          ThisType greater_than_umin_less_umax = patch.split_u(u_min)[0];
+
+          // 3. Split patch on u_min <= u <= umax at v_min  in the v dir, take
+          // the patch >= v_min
+          ThisType greater_than_vmin = greater_than_umin_less_umax[1];
+
+          // 4. Split patch  at v_max in the v dir, take the patch <= v_max
+          ThisType greater_than_vmin_less_vmax = greater_than_vmin[0];
+          return greater_than_vmin_less_vmax;
+        }
+
 };
 
 }

--- a/include/nanospline/BezierBase.h
+++ b/include/nanospline/BezierBase.h
@@ -26,6 +26,12 @@ class BezierBase : public CurveBase<_Scalar, _dim> {
         virtual Point evaluate_derivative(Scalar t) const override =0;
         virtual Point evaluate_2nd_derivative(Scalar t) const override =0;
 
+        virtual bool in_domain(Scalar t) const {
+            constexpr Scalar eps = std::numeric_limits<Scalar>::epsilon();
+            const Scalar t_min = 0.;
+            const Scalar t_max = 1.;
+            return (t >= t_min - eps) && (t <= t_max + eps);
+        }
         virtual Scalar approximate_inverse_evaluate(const Point& p,
                 const Scalar lower=0.0,
                 const Scalar upper=1.0,

--- a/include/nanospline/BezierBase.h
+++ b/include/nanospline/BezierBase.h
@@ -26,7 +26,7 @@ class BezierBase : public CurveBase<_Scalar, _dim> {
         virtual Point evaluate_derivative(Scalar t) const override =0;
         virtual Point evaluate_2nd_derivative(Scalar t) const override =0;
 
-        virtual bool in_domain(Scalar t) const {
+        virtual bool in_domain(Scalar t) const override {
             constexpr Scalar eps = std::numeric_limits<Scalar>::epsilon();
             const Scalar t_min = 0.;
             const Scalar t_max = 1.;
@@ -82,11 +82,11 @@ class BezierBase : public CurveBase<_Scalar, _dim> {
             return _generic ? static_cast<int>(m_control_points.rows())-1 : _degree;
         }
 
-        Scalar get_domain_lower_bound() const {
+        Scalar get_domain_lower_bound() const override {
             return 0.0;
         }
 
-        Scalar get_domain_upper_bound() const {
+        Scalar get_domain_upper_bound() const override {
             return 1.0;
         }
 

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -1,9 +1,14 @@
 #pragma once
 
 #include <nanospline/PatchBase.h>
+#include <nanospline/split.h>
 #include <nanospline/Bezier.h>
 #include <nanospline/Exceptions.h>
+#include <vector>
+#include <iostream>
 
+        using std::cout;
+        using std::endl;
 namespace nanospline {
 
 template<typename _Scalar, int _dim=3,
@@ -14,6 +19,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
         static_assert(_dim > 0, "Dimension must be positive.");
 
         using Base = PatchBase<_Scalar, _dim>;
+        using ThisType = BezierPatch<_Scalar, _dim, _degree_u, _degree_v>;
         using Scalar = typename Base::Scalar;
         using Point = typename Base::Point;
         using ControlGrid = typename Base::ControlGrid;
@@ -97,17 +103,11 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
 
     public:
         IsoCurveU compute_iso_curve_u(Scalar v) const {
-            const int degree_u = Base::get_degree_u();
-            const int degree_v = Base::get_degree_v();
-            typename IsoCurveU::ControlPoints control_points_u(degree_u+1, _dim);
-            for (int i=0; i<=degree_u; i++) {
-                typename IsoCurveV::ControlPoints control_points_v(degree_v+1, _dim);
-                for (int j=0; j<=degree_v; j++) {
-                    control_points_v.row(j) = get_control_point(i, j);
-                }
-
-                IsoCurveV iso_curve_v;
-                iso_curve_v.set_control_points(std::move(control_points_v));
+            typename IsoCurveU::ControlPoints control_points_u(num_control_points_u(), _dim);
+            
+            std::vector<IsoCurveV> iso_curves_v = get_all_iso_curves_v();
+            for (int i=0; i < num_control_points_u(); i++) {
+                IsoCurveV iso_curve_v = iso_curves_v[i];
                 control_points_u.row(i) = iso_curve_v.evaluate(v);
             }
 
@@ -117,20 +117,13 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
         }
 
         IsoCurveV compute_iso_curve_v(Scalar u) const {
-            const int degree_u = Base::get_degree_u();
-            const int degree_v = Base::get_degree_v();
-            typename IsoCurveV::ControlPoints control_points_v(degree_v+1, _dim);
-            for (int j=0; j<=degree_v; j++) {
-                typename IsoCurveU::ControlPoints control_points_u(degree_u+1, _dim);
-                for (int i=0; i<=degree_u; i++) {
-                    control_points_u.row(i) = get_control_point(i, j);
-                }
-
-                IsoCurveU iso_curve_u;
-                iso_curve_u.set_control_points(std::move(control_points_u));
-                control_points_v.row(j) = iso_curve_u.evaluate(u);
+            typename IsoCurveV::ControlPoints control_points_v(num_control_points_v(), _dim);
+            
+            std::vector<IsoCurveU> iso_curves_u = get_all_iso_curves_u();
+            for (int i=0; i < num_control_points_v(); i++) {
+                IsoCurveU iso_curve = iso_curves_u[i];
+                control_points_v.row(i) = iso_curve.evaluate(u);
             }
-
             IsoCurveV iso_curve_v;
             iso_curve_v.set_control_points(std::move(control_points_v));
             return iso_curve_v;
@@ -214,12 +207,222 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
             return duv_patch;
         }
 
-    protected:
+
         Point get_control_point(int ui, int vj) const {
-            const auto degree_v = Base::get_degree_v();
-            const auto row_size = degree_v + 1;
-            return Base::m_control_grid.row(ui*row_size + vj);
+            return Base::m_control_grid.row(ui*num_control_points_v()+vj);
+        }
+        int num_control_points_u() const{
+            const int degree_u = Base::get_degree_u();
+            return degree_u + 1;
+        }
+        int num_control_points_v() const{
+            const int degree_v = Base::get_degree_v();
+            return degree_v + 1;
+        }
+    private: 
+
+        // Translate (i,j) control point indexing into a linear index. Note that
+        // control points are ordered in v-major order
+        int control_point_linear_index(int i, int j) const {
+            return i*(num_control_points_v()) + j;
+        }
+        
+        // Construct the implicit isocurves determined by each column of control points
+        // i.e. fixed values of u. This copies these columns into
+        // individual matrices of control points and returns the resulting
+        // curves
+        std::vector<IsoCurveV> get_all_iso_curves_v() const {
+            
+            std::vector<IsoCurveV> iso_curves;
+            for (int ui = 0; ui < num_control_points_u(); ui++) {
+              typename IsoCurveV::ControlPoints control_points_v(
+                  num_control_points_v(), _dim);
+              for (int vj = 0; vj < num_control_points_v(); vj++) {
+                control_points_v.row(vj) = get_control_point(ui, vj);
+              }
+
+              IsoCurveV iso_curve_v;
+              iso_curve_v.set_control_points(std::move(control_points_v));
+              iso_curves.push_back(iso_curve_v);
+            }
+            return iso_curves;
+        }
+        
+        // Construct the implicit isocurves determined by each rows of control points
+        // i.e. fixed values of v. This copies these rows into
+        // individual matrices of control points and returns the resulting
+        // curves
+        std::vector<IsoCurveU> get_all_iso_curves_u() const {
+
+          std::vector<IsoCurveU> iso_curves;
+          for (int vj = 0; vj < num_control_points_v(); vj++) {
+            typename IsoCurveU::ControlPoints control_points_u( num_control_points_u(), _dim);
+
+            for (int ui = 0; ui < num_control_points_u(); ui++) {
+              control_points_u.row(ui) = get_control_point(ui, vj);
+            }
+
+            IsoCurveU iso_curve_u;
+            iso_curve_u.set_control_points(std::move(control_points_u));
+            iso_curves.push_back(iso_curve_u);
+          }
+          return iso_curves;
+        }
+
+      public:
+        
+        // Split a patch into two patches along the vertical line at u
+        std::vector<ThisType> split_u(Scalar u) {
+            // TODO domain checking
+          const int num_split_patches = 2; // splitting one patch into two
+          std::vector<IsoCurveU> iso_curves_u = get_all_iso_curves_u();
+
+          // Initialize control grids of final split patches
+          std::vector<ControlGrid> split_control_pts_u(num_split_patches, 
+                  ControlGrid(this->num_control_points(), _dim));
+
+          for (int vj = 0; vj < num_control_points_v(); vj++) {
+            // split each isocurve
+            IsoCurveU iso_curve = iso_curves_u[vj];
+            std::vector<IsoCurveU> split_iso_curves = nanospline::split(iso_curve, u);
+
+            // Copy control points of each split curve to its proper place in
+            // the final control grid
+            for (int ci = 0; ci < num_split_patches; ci++) {
+              const auto &ctrl_pts = split_iso_curves[ci].get_control_points();
+
+              for (int ui = 0; ui < num_control_points_u(); ui++) {
+                int index = control_point_linear_index(ui, vj);
+                split_control_pts_u[ci].row(index) = ctrl_pts.row(ui);
+              }
+            }
+          }
+
+          ThisType patch_less_than_u;
+          ThisType patch_greater_than_u;
+          patch_less_than_u.set_control_grid(split_control_pts_u[0]);
+          patch_greater_than_u.set_control_grid(split_control_pts_u[1]);
+
+          return {patch_less_than_u, patch_greater_than_u};
+        }
+
+        // Split a patch into two patches along the horizontal line at v 
+        std::vector<ThisType> split_v(Scalar v) {
+            // TODO domain checking
+          const int num_split_patches = 2; // splitting one patch into two
+
+          std::vector<IsoCurveV> iso_curves_v = get_all_iso_curves_v();
+
+          std::vector<ControlGrid> split_control_pts_v(num_split_patches, 
+                  ControlGrid(this->num_control_points(), _dim));
+
+          for (int ui = 0; ui < num_control_points_u(); ui++) {
+            // split each isocurve
+            IsoCurveV iso_curve = iso_curves_v[ui];
+            std::vector<IsoCurveV> split_iso_curves = iso_curve.split(v);
+
+            // Copy control points of each split curve to its proper place in
+            // the final control grid
+            for (int ci = 0; ci < num_split_patches; ci++) {
+              auto ctrl_pts = split_iso_curves[ci].get_control_points();
+
+              for (int vj = 0; vj < num_control_points_v(); vj++) {
+                int index = control_point_linear_index(ui, vj);
+                split_control_pts_v[ci].row(index) = ctrl_pts.row(vj);
+              }
+            }
+          }
+
+          ThisType patch_less_than_v;
+          ThisType patch_greater_than_v;
+          patch_less_than_v.set_control_grid(split_control_pts_v[0]);
+          patch_greater_than_v.set_control_grid(split_control_pts_v[1]);
+
+          return {patch_less_than_v, patch_greater_than_v};
+        }
+
+    public: 
+        std::vector<ThisType> split(Scalar u, Scalar v) {
+          if (this->is_endpoint_u(u) &&
+              this->is_endpoint_v(v)) { // no splitting required
+            return std::vector<ThisType>{*this};
+
+          } else if (this->is_endpoint_u(u)) { // no need to split along u
+            return split_v(v);
+
+          } else if (this->is_endpoint_v(v)) { // no need to split along v
+            return split_u(u);
+
+          } else {
+
+            // 1. split in u direction
+            std::vector<ThisType> split_patches = split_u(u);
+            ThisType less_than_u = split_patches[0];
+            ThisType greater_than_u = split_patches[1];
+
+            // 2. Split each subpatch patch at v
+
+            std::vector<ThisType> split_patches_less_than_u =
+                less_than_u.split_v(v);
+
+            std::vector<ThisType> split_patches_greater_than_u =
+                greater_than_u.split_v(v);
+
+            // 3. Reorder. The patch is split into 4 patches returned in the
+            // following order:
+            //
+            //   |-----------|
+            //   |  1  |  3  |
+            // ^ |-----*-----| *= split point (u,v)
+            // | |  0  |  2  |
+            // v |-----------|
+            //    u ->
+
+            ThisType less_than_u_less_than_v = split_patches_less_than_u[0];
+            ThisType less_than_u_greater_than_v = split_patches_less_than_u[1];
+            ThisType greater_than_u_less_than_v =
+                split_patches_greater_than_u[0];
+            ThisType greater_than_u_greater_than_v =
+                split_patches_greater_than_u[1];
+
+            return {less_than_u_less_than_v, less_than_u_greater_than_v,
+                    greater_than_u_less_than_v, greater_than_u_greater_than_v};
+          }
+        }
+
+        std::vector<ThisType> subpatch(const ThisType &patch, Scalar u_min,
+                                       Scalar u_max, Scalar v_min,
+                                       Scalar v_max) {
+          if (u_min > u_max) {
+            throw invalid_setting_error("u_min must be smaller than u_max");
+          }
+          if (u_min < 0 || u_min > 1 || u_max < 0 || u_max > 1) {
+            throw invalid_setting_error("Invalid range in subcurve: u");
+          }
+          if (v_min > v_max) {
+            throw invalid_setting_error("v_min must be smaller than v_max");
+          }
+          if (v_min < 0 || v_min > 1 || v_max < 0 || v_max > 1) {
+            throw invalid_setting_error("Invalid range in subcurve: u");
+          }
+        
+          // TODO add domain handling to reduce computation
+          //
+          // 1. Split patch in u direction at u_min; take the patch on >= u_min
+          ThisType greater_than_umin = patch.split_u(u_min)[1];
+
+          // 2. Split patch on >= u_min at u_max in u dir; take the patch <=
+          // u_max
+          ThisType greater_than_umin_less_umax = patch.split_u(u_min)[0];
+
+          // 3. Split patch on u_min <= u <= umax at v_min  in the v dir, take
+          // the patch >= v_min
+          ThisType greater_than_vmin = greater_than_umin_less_umax[1];
+
+          // 4. Split patch  at v_max in the v dir, take the patch <= v_max
+          ThisType greater_than_vmin_less_vmax = greater_than_vmin[0];
+          return greater_than_vmin_less_vmax;
         }
 };
 
-}
+} // namespace nanospline

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <cstddef>
 #include <nanospline/PatchBase.h>
-#include <nanospline/split.h>
 #include <nanospline/Bezier.h>
-#include <nanospline/Exceptions.h>
-#include <vector>
-#include <iostream>
 
-        using std::cout;
-        using std::endl;
 namespace nanospline {
 
 template<typename _Scalar, int _dim=3,
@@ -101,6 +94,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
         Scalar get_v_upper_bound() const override {
             return 1.0;
         }
+
         UVPoint get_control_point_preimage(int i, int j) const  override {
             UVPoint preimage;
             preimage << Scalar(i)/Scalar(Base::get_degree_u()), 
@@ -217,7 +211,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
 
 
         Point get_control_point(int ui, int vj) const override {
-            return Base::m_control_grid.row(ui*num_control_points_v()+vj);
+            return Base::m_control_grid.row(Base::control_point_linear_index(ui,vj));
         }
         int num_control_points_u() const override {
             const int degree_u = Base::get_degree_u();
@@ -229,12 +223,6 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
         }
     private: 
 
-        // Translate (i,j) control point indexing into a linear index. Note that
-        // control points are ordered in v-major order
-        int control_point_linear_index(int i, int j) const {
-            return i*(num_control_points_v()) + j;
-        }
-        
         // Construct the implicit isocurves determined by each column of control points
         // i.e. fixed values of u. This copies these columns into
         // individual matrices of control points and returns the resulting
@@ -281,13 +269,20 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
         
         // Split a patch into two patches along the vertical line at u
         std::vector<ThisType> split_u(Scalar u) const {
-            // TODO domain checking
+          if (!Base::in_domain_u(u)) {
+            throw invalid_setting_error("Parameter not inside of the domain.");
+          }
+          if (Base::is_endpoint_u(u)) { // no split required
+            return std::vector<ThisType>{*this};
+          }
+
           const int num_split_patches = 2; // splitting one patch into two
           std::vector<IsoCurveU> iso_curves_u = get_all_iso_curves_u();
 
           // Initialize control grids of final split patches
-          std::vector<ControlGrid> split_control_pts_u(num_split_patches, 
-                  ControlGrid(this->num_control_points(), _dim));
+          std::vector<ControlGrid> split_control_pts_u(
+                  num_split_patches, ControlGrid(Base::num_control_points(), _dim)
+              );
 
           for (int vj = 0; vj < num_control_points_v(); vj++) {
             // split each isocurve
@@ -300,7 +295,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
               const auto &ctrl_pts = split_iso_curves[ci].get_control_points();
 
               for (int ui = 0; ui < num_control_points_u(); ui++) {
-                int index = control_point_linear_index(ui, vj);
+                int index = Base::control_point_linear_index(ui, vj);
                 split_control_pts_u[ci].row(index) = ctrl_pts.row(ui);
               }
             }
@@ -314,20 +309,26 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
           return {patch_less_than_u, patch_greater_than_u};
         }
 
-        // Split a patch into two patches along the horizontal line at v 
+        // Split a patch into two patches along the horizontal line at v
         std::vector<ThisType> split_v(Scalar v) const {
-            // TODO domain checking
+          if (!Base::in_domain_v(v)) {
+            throw invalid_setting_error("Parameter not inside of the domain.");
+          }
+          if (Base::is_endpoint_v(v)) { // no split required
+            return std::vector<ThisType>{*this};
+          }
           const int num_split_patches = 2; // splitting one patch into two
 
           std::vector<IsoCurveV> iso_curves_v = get_all_iso_curves_v();
 
-          std::vector<ControlGrid> split_control_pts_v(num_split_patches, 
-                  ControlGrid(this->num_control_points(), _dim));
+          std::vector<ControlGrid> split_control_pts_v(
+              num_split_patches, ControlGrid(Base::num_control_points(), _dim));
 
           for (int ui = 0; ui < num_control_points_u(); ui++) {
             // split each isocurve
             IsoCurveV iso_curve = iso_curves_v[static_cast<size_t>(ui)];
-            std::vector<IsoCurveV> split_iso_curves = nanospline::split(iso_curve, v);
+            std::vector<IsoCurveV> split_iso_curves =
+                nanospline::split(iso_curve, v);
 
             // Copy control points of each split curve to its proper place in
             // the final control grid
@@ -335,7 +336,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
               auto ctrl_pts = split_iso_curves[ci].get_control_points();
 
               for (int vj = 0; vj < num_control_points_v(); vj++) {
-                int index = control_point_linear_index(ui, vj);
+                int index = Base::control_point_linear_index(ui, vj);
                 split_control_pts_v[ci].row(index) = ctrl_pts.row(vj);
               }
             }
@@ -349,171 +350,143 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
           return {patch_less_than_v, patch_greater_than_v};
         }
 
-    public: 
-        std::vector<ThisType> split(Scalar u, Scalar v) const {
-          if (this->is_endpoint_u(u) &&
-              this->is_endpoint_v(v)) { // no splitting required
-            return std::vector<ThisType>{*this};
+    public:
+      std::vector<ThisType> split(Scalar u, Scalar v) const {
+        if (Base::is_endpoint_u(u) &&
+            Base::is_endpoint_v(v)) { // no splitting required
+          return std::vector<ThisType>{*this};
 
-          } else if (this->is_endpoint_u(u)) { // no need to split along u
-            return split_v(v);
+        } else if (Base::is_endpoint_u(u)) { // no need to split along u
+          return split_v(v);
 
-          } else if (this->is_endpoint_v(v)) { // no need to split along v
-            return split_u(u);
+        } else if (Base::is_endpoint_v(v)) { // no need to split along v
+          return split_u(u);
 
-          } else {
+        } else {
 
-            // 1. split in u direction
-            std::vector<ThisType> split_patches = split_u(u);
-            ThisType less_than_u = split_patches[0];
-            ThisType greater_than_u = split_patches[1];
+          // 1. split in u direction
+          std::vector<ThisType> split_patches = split_u(u);
+          ThisType less_than_u = split_patches[0];
+          ThisType greater_than_u = split_patches[1];
 
-            // 2. Split each subpatch patch at v
+          // 2. Split each subpatch patch at v
 
-            std::vector<ThisType> split_patches_less_than_u =
-                less_than_u.split_v(v);
+          std::vector<ThisType> split_patches_less_than_u =
+              less_than_u.split_v(v);
 
-            std::vector<ThisType> split_patches_greater_than_u =
-                greater_than_u.split_v(v);
+          std::vector<ThisType> split_patches_greater_than_u =
+              greater_than_u.split_v(v);
 
-            // 3. Reorder. The patch is split into 4 patches returned in the
-            // following order:
-            //
-            //   |-----------|
-            //   |  1  |  3  |
-            // ^ |-----*-----| *= split point (u,v)
-            // | |  0  |  2  |
-            // v |-----------|
-            //    u ->
+          // 3. Reorder. The patch is split into 4 patches returned in the
+          // following order:
+          //
+          //   |-----------|
+          //   |  1  |  3  |
+          // ^ |-----*-----| *= split point (u,v)
+          // | |  0  |  2  |
+          // v |-----------|
+          //    u ->
 
-            ThisType less_than_u_less_than_v = split_patches_less_than_u[0];
-            ThisType less_than_u_greater_than_v = split_patches_less_than_u[1];
-            ThisType greater_than_u_less_than_v =
-                split_patches_greater_than_u[0];
-            ThisType greater_than_u_greater_than_v =
-                split_patches_greater_than_u[1];
+          ThisType less_than_u_less_than_v       = split_patches_less_than_u[0];
+          ThisType less_than_u_greater_than_v    = split_patches_less_than_u[1];
+          ThisType greater_than_u_less_than_v    = split_patches_greater_than_u[0];
+          ThisType greater_than_u_greater_than_v = split_patches_greater_than_u[1];
 
-            return {less_than_u_less_than_v, less_than_u_greater_than_v,
-                    greater_than_u_less_than_v, greater_than_u_greater_than_v};
-          }
+          return {less_than_u_less_than_v, less_than_u_greater_than_v,
+                  greater_than_u_less_than_v, greater_than_u_greater_than_v};
         }
+      }
 
         ThisType subpatch(Scalar u_min, Scalar u_max, Scalar v_min,
                           Scalar v_max) const {
           if (u_min > u_max) {
             throw invalid_setting_error("u_min must be smaller than u_max");
           }
-          if (u_min < 0 || u_min > 1 || u_max < 0 || u_max > 1) {
+          if (!Base::in_domain_u(u_min) || !Base::in_domain_u(u_max)) {
             throw invalid_setting_error("Invalid range in subcurve: u");
           }
+
           if (v_min > v_max) {
             throw invalid_setting_error("v_min must be smaller than v_max");
           }
-          if (v_min < 0 || v_min > 1 || v_max < 0 || v_max > 1) {
-            throw invalid_setting_error("Invalid range in subcurve: u");
+          if (!Base::in_domain_v(v_min) || !Base::in_domain_v(v_max)) {
+            throw invalid_setting_error("Invalid range in subcurve: v");
           }
-          //if (this->is_endpoint_u(u) &&
-          //this->is_endpoint_v(v)) { // no splitting required
-          ThisType greater_than_umin;
-          ThisType greater_than_umin_less_umax;
-          ThisType greater_than_vmin;
-          ThisType greater_than_vmin_less_vmax;
-          
+          // Note: conditionals are for bound checking to avoid redundant splits
           // 1. Split patch in u direction at u_min; take the patch on >= u_min
-          if (this->is_endpoint_u(u_min)){
-              greater_than_umin = *this;
-          } else {
-              greater_than_umin = split_u(u_min)[1];
-          }
-          
+          ThisType greater_than_umin =
+              Base::is_endpoint_u(u_min) ? *this : split_u(u_min)[1];
+
           // 2. Split patch on >= u_min at u_max in u dir; take the patch <=
-          if (this->is_endpoint_u(u_max)){
-              greater_than_umin_less_umax = greater_than_umin;
-          } else {
-            greater_than_umin_less_umax = greater_than_umin.split_u(u_max)[0];
-          }
+          // u_max
+          ThisType greater_than_umin_less_umax =
+              Base::is_endpoint_u(u_max) ? greater_than_umin
+                                         : greater_than_umin.split_u(u_max)[0];
 
           // 3. Split patch on u_min <= u <= umax at v_min  in the v dir, take
-          if (this->is_endpoint_v(v_min)) {
-              greater_than_vmin = greater_than_umin_less_umax;
-          } else {
-            greater_than_vmin = greater_than_umin_less_umax.split_v(v_min)[1];
-          } 
+          // the patch >= v_min
+          ThisType greater_than_vmin =
+              Base::is_endpoint_v(v_min)
+                  ? greater_than_umin_less_umax
+                  : greater_than_umin_less_umax.split_v(v_min)[1];
 
           // 4. Split patch  at v_max in the v dir, take the patch <= v_max
-          if(this->is_endpoint_v(v_max)){
-              greater_than_vmin_less_vmax = greater_than_vmin;
-          } else {
-            greater_than_vmin_less_vmax = greater_than_vmin.split_v(v_max)[0];
-          }
-          
+          ThisType greater_than_vmin_less_vmax =
+              Base::is_endpoint_v(v_max) ? greater_than_vmin
+                                         : greater_than_vmin.split_v(v_max)[0];
+
           return greater_than_vmin_less_vmax;
         }
 
-        UVPoint approximate_inverse_evaluate(
-                const Point& p,
-                const int num_samples,
-                const Scalar min_u,
-                const Scalar max_u,
-                const Scalar min_v,
-                const Scalar max_v,
-                const int level=15) const override {
-            
-            // Only two control points at the endpoints, so finding the closest
-            // point doesn't restrict the search at all; default to the parent
-            // class function based on sampling where resolution isn't an issue
-            if (Base::get_degree_u() < 2 || Base::get_degree_v() < 2){
-                return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
-            }
-            
-            // 1. find closest control point
-            Scalar min_dist = std::numeric_limits<Scalar>::max();
-            int i_min =0;
-            int j_min =0;
-            for (int ui = 0; ui < num_control_points_u(); ui++) {
-              for (int vj = 0; vj < num_control_points_v(); vj++) {
-                  Point control_point = get_control_point(ui, vj);
-                 const auto dist = (p - control_point).squaredNorm();
+        UVPoint approximate_inverse_evaluate(const Point &p, const int num_samples,
+                                     const Scalar min_u, const Scalar max_u,
+                                     const Scalar min_v, const Scalar max_v,
+                                     const int level = 15) const override {
 
-                 if(dist < min_dist){
-                     min_dist = dist;
-                     i_min = ui;
-                     j_min = vj;
+          // Only two control points at the endpoints, so finding the closest
+          // point doesn't restrict the search at all; default to the parent
+          // class function based on sampling where resolution isn't an issue
+          if (Base::get_degree_u() < 2 || Base::get_degree_v() < 2) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u,
+                                                      max_u, min_v, max_v);
+          }
 
-                 }
-              }
-            }
-            if (level <= 0) {
-                return get_control_point_preimage(i_min, j_min);
+          // 1. find closest control point
+          auto closest_control_pt_index = Base::find_closest_control_point(p);
+          int i_min = closest_control_pt_index.first;
+          int j_min = closest_control_pt_index.second;
 
-            } else {
+          if (level <= 0) {
+            return get_control_point_preimage(i_min, j_min);
 
-            // Control points c_{i+/-1,j+/-1} bound the domain
-            // 2. find subdomain corresponding to control point subdomain boundary
+          } else {
+
+            // 2. Control points c_{i+/-1,j+/-1} bound the domain containing our
+            // desired initial guess; find subdomain corresponding to control
+            // point subdomain boundary
+            // Conditionals for bound checking
             UVPoint uv_min = get_control_point_preimage(
-                    i_min > 0 ? i_min-1: i_min,
-                    j_min > 0 ? j_min-1: j_min);
+                i_min > 0 ? i_min - 1 : i_min, j_min > 0 ? j_min - 1 : j_min);
             UVPoint uv_max = get_control_point_preimage(
-                    i_min < num_control_points_u() -1? i_min+1 : i_min,
-                    j_min < num_control_points_v() -1? j_min+1 : j_min);
-            
-            // 3. split a subcurve to find closest ctrl points on subdomain
-            ThisType patch = subpatch(uv_min(0), uv_max(0), uv_min(1), uv_max(1));
+                i_min < num_control_points_u() - 1 ? i_min + 1 : i_min,
+                j_min < num_control_points_v() - 1 ? j_min + 1 : j_min);
 
-            // repeat recursively
-            UVPoint uv =  patch.approximate_inverse_evaluate(p, num_samples,
-            uv_min(0), uv_max(0), uv_min(1), uv_max(1), level-1);
-            // remap solution up through affine subdomain transformations
-            uv(0) = (uv_max(0)-uv_min(0))*uv(0) + uv_min(0);
-            uv(1) = (uv_max(1)-uv_min(1))*uv(1) + uv_min(1);
+            // 3. split a subcurve to find closest ctrl points on subdomain
+            ThisType patch =
+                subpatch(uv_min(0), uv_max(0), uv_min(1), uv_max(1));
+
+            // 4. repeat recursively
+            UVPoint uv = patch.approximate_inverse_evaluate(
+                p, num_samples, uv_min(0), uv_max(0), uv_min(1), uv_max(1),
+                level - 1);
+
+            // 5. remap solution up through affine subdomain transformations
+            uv(0) = (uv_max(0) - uv_min(0)) * uv(0) + uv_min(0);
+            uv(1) = (uv_max(1) - uv_min(1)) * uv(1) + uv_min(1);
 
             return uv;
-            }
-
-
+          }
         }
-
-
 };
 
 } // namespace nanospline

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <nanospline/PatchBase.h>
 #include <nanospline/split.h>
 #include <nanospline/Bezier.h>
@@ -107,7 +108,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
             
             std::vector<IsoCurveV> iso_curves_v = get_all_iso_curves_v();
             for (int i=0; i < num_control_points_u(); i++) {
-                IsoCurveV iso_curve_v = iso_curves_v[i];
+                IsoCurveV iso_curve_v = iso_curves_v[size_t(i)];
                 control_points_u.row(i) = iso_curve_v.evaluate(v);
             }
 
@@ -121,7 +122,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
             
             std::vector<IsoCurveU> iso_curves_u = get_all_iso_curves_u();
             for (int i=0; i < num_control_points_v(); i++) {
-                IsoCurveU iso_curve = iso_curves_u[i];
+                IsoCurveU iso_curve = iso_curves_u[size_t(i)];
                 control_points_v.row(i) = iso_curve.evaluate(u);
             }
             IsoCurveV iso_curve_v;
@@ -208,14 +209,14 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
         }
 
 
-        Point get_control_point(int ui, int vj) const {
+        Point get_control_point(int ui, int vj) const override {
             return Base::m_control_grid.row(ui*num_control_points_v()+vj);
         }
-        int num_control_points_u() const{
+        int num_control_points_u() const override {
             const int degree_u = Base::get_degree_u();
             return degree_u + 1;
         }
-        int num_control_points_v() const{
+        int num_control_points_v() const override {
             const int degree_v = Base::get_degree_v();
             return degree_v + 1;
         }
@@ -283,12 +284,12 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
 
           for (int vj = 0; vj < num_control_points_v(); vj++) {
             // split each isocurve
-            IsoCurveU iso_curve = iso_curves_u[vj];
+            IsoCurveU iso_curve = iso_curves_u[static_cast<size_t>(vj)];
             std::vector<IsoCurveU> split_iso_curves = nanospline::split(iso_curve, u);
 
             // Copy control points of each split curve to its proper place in
             // the final control grid
-            for (int ci = 0; ci < num_split_patches; ci++) {
+            for (size_t ci = 0; ci < num_split_patches; ci++) {
               const auto &ctrl_pts = split_iso_curves[ci].get_control_points();
 
               for (int ui = 0; ui < num_control_points_u(); ui++) {
@@ -318,12 +319,12 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
 
           for (int ui = 0; ui < num_control_points_u(); ui++) {
             // split each isocurve
-            IsoCurveV iso_curve = iso_curves_v[ui];
+            IsoCurveV iso_curve = iso_curves_v[static_cast<size_t>(ui)];
             std::vector<IsoCurveV> split_iso_curves = iso_curve.split(v);
 
             // Copy control points of each split curve to its proper place in
             // the final control grid
-            for (int ci = 0; ci < num_split_patches; ci++) {
+            for (size_t ci = 0; ci < num_split_patches; ci++) {
               auto ctrl_pts = split_iso_curves[ci].get_control_points();
 
               for (int vj = 0; vj < num_control_points_v(); vj++) {

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -100,7 +100,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
         Scalar get_v_upper_bound() const override {
             return 1.0;
         }
-
+        
 
     public:
         IsoCurveU compute_iso_curve_u(Scalar v) const {
@@ -320,7 +320,7 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
           for (int ui = 0; ui < num_control_points_u(); ui++) {
             // split each isocurve
             IsoCurveV iso_curve = iso_curves_v[static_cast<size_t>(ui)];
-            std::vector<IsoCurveV> split_iso_curves = iso_curve.split(v);
+            std::vector<IsoCurveV> split_iso_curves = nanospline::split(iso_curve, v);
 
             // Copy control points of each split curve to its proper place in
             // the final control grid

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -468,7 +468,8 @@ class BezierPatch final : public PatchBase<_Scalar, _dim> {
             
             // 1. find closest control point
             Scalar min_dist = std::numeric_limits<Scalar>::max();
-            int i_min, j_min;
+            int i_min =0;
+            int j_min =0;
             for (int ui = 0; ui < num_control_points_u(); ui++) {
               for (int vj = 0; vj < num_control_points_v(); vj++) {
                   Point control_point = get_control_point(ui, vj);

--- a/include/nanospline/CurveBase.h
+++ b/include/nanospline/CurveBase.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <cmath>
 #include <limits>
 #include <vector>

--- a/include/nanospline/CurveBase.h
+++ b/include/nanospline/CurveBase.h
@@ -7,7 +7,7 @@
 #include <memory>
 
 #include <Eigen/Core>
-
+#include <nanospline/Exceptions.h>
 namespace nanospline {
 
 template<typename _Scalar, int _dim>
@@ -23,7 +23,9 @@ class CurveBase {
         virtual Scalar inverse_evaluate(const Point& p) const =0;
         virtual Point evaluate_derivative(Scalar t) const =0;
         virtual Point evaluate_2nd_derivative(Scalar t) const =0;
-
+        virtual bool in_domain(Scalar t) const =0;
+        virtual Scalar get_domain_lower_bound() const =0;
+        virtual Scalar get_domain_upper_bound() const =0;
         virtual Scalar approximate_inverse_evaluate(const Point& p,
                 const Scalar lower=0.0,
                 const Scalar upper=1.0,
@@ -42,7 +44,6 @@ class CurveBase {
                 const Scalar upper=1.0) const =0;
 
         virtual void write(std::ostream &out) const =0;
-
         virtual Scalar get_turning_angle(Scalar t0, Scalar t1) const {
             if (_dim != 2) {
                 throw std::runtime_error(
@@ -70,6 +71,17 @@ class CurveBase {
         }
 
     public:
+      bool is_split_point_valid(Scalar t) const {
+        if (!in_domain(t)) {
+          throw invalid_setting_error("Parameter not inside of the domain.");
+        }
+        if (t == get_domain_lower_bound() || t == get_domain_upper_bound()) {
+          return false;
+        } else {
+          return true;
+        }
+      }
+
         Point evaluate_curvature(Scalar t) const {
             const auto d1 = evaluate_derivative(t);
             const auto d2 = evaluate_2nd_derivative(t);

--- a/include/nanospline/NURBSPatch.h
+++ b/include/nanospline/NURBSPatch.h
@@ -30,10 +30,10 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
         }
 
     public:
-        int num_control_points_u() const {
+        int num_control_points_u() const override {
             return m_homogeneous.num_control_points_u();
         }
-        int num_control_points_v() const {
+        int num_control_points_v() const override {
             return m_homogeneous.num_control_points_v();
         }
         Point get_control_point(int i, int j) const override {

--- a/include/nanospline/NURBSPatch.h
+++ b/include/nanospline/NURBSPatch.h
@@ -30,6 +30,17 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
         }
 
     public:
+        int num_control_points_u() const {
+            return m_homogeneous.num_control_points_u();
+        }
+        int num_control_points_v() const {
+            return m_homogeneous.num_control_points_v();
+        }
+        Point get_control_point(int i, int j) const override {
+            Eigen::Matrix<Scalar, 1, _dim+1> control_point = m_homogeneous.get_control_point(i,j);
+            return control_point.head(_dim);
+        }
+
         Point evaluate(Scalar u, Scalar v) const override {
             validate_initialization();
             const auto p = m_homogeneous.evaluate(u, v);

--- a/include/nanospline/NURBSPatch.h
+++ b/include/nanospline/NURBSPatch.h
@@ -45,8 +45,7 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
         }
 
         Point get_control_point(int i, int j) const override {
-            Eigen::Matrix<Scalar, 1, _dim+1> control_point = m_homogeneous.get_control_point(i,j);
-            return control_point.head(_dim);
+            return Base::m_control_grid.row(Base::control_point_linear_index(i,j));
         }
 
         Point evaluate(Scalar u, Scalar v) const override {
@@ -160,25 +159,29 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
         }
 
         Scalar get_u_lower_bound() const override {
-            const int degree_u = Base::get_degree_u();
-            return m_knots_u[degree_u];
+            return m_homogeneous.get_u_lower_bound();
+//            const int degree_u = Base::get_degree_u();
+//            return m_knots_u[degree_u];
         }
 
         Scalar get_v_lower_bound() const override {
-            const int degree_v = Base::get_degree_v();
-            return m_knots_v[degree_v];
+            return m_homogeneous.get_v_lower_bound();
+//            const int degree_v = Base::get_degree_v();
+//            return m_knots_v[degree_v];
         }
 
         Scalar get_u_upper_bound() const override {
-            const auto num_knots = static_cast<int>(m_knots_u.rows());
-            const int degree_u = Base::get_degree_u();
-            return m_knots_u[num_knots-degree_u-1];
+            return m_homogeneous.get_u_upper_bound();
+//            const auto num_knots = static_cast<int>(m_knots_u.rows());
+//            const int degree_u = Base::get_degree_u();
+//            return m_knots_u[num_knots-degree_u-1];
         }
 
         Scalar get_v_upper_bound() const override {
-            const auto num_knots = static_cast<int>(m_knots_v.rows());
-            const int degree_v = Base::get_degree_v();
-            return m_knots_v[num_knots-degree_v-1];
+            return m_homogeneous.get_v_upper_bound();
+//            const auto num_knots = static_cast<int>(m_knots_v.rows());
+//            const int degree_v = Base::get_degree_v();
+//            return m_knots_v[num_knots-degree_v-1];
         }
 
     public:
@@ -251,6 +254,8 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
                 / m_weights.array();
             m_knots_u = homogeneous.get_knots_u();
             m_knots_v = homogeneous.get_knots_v();
+            Base::m_degree_u = homogeneous.get_degree_u();
+            Base::m_degree_v = homogeneous.get_degree_v();
             validate_initialization();
         }
         
@@ -289,60 +294,58 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
             return results;
 
         }
-        UVPoint approximate_inverse_evaluate(const Point& p,
-                const int num_samples,
-                const Scalar min_u,
-                const Scalar max_u,
-                const Scalar min_v,
-                const Scalar max_v,
-                const int level=3) const {
-            
-            // 1. find closest control point
-            Scalar min_dist = std::numeric_limits<Scalar>::max();
-            int i_min, j_min;
-            for (int ui = 0; ui < num_control_points_u(); ui++) {
-              for (int vj = 0; vj < num_control_points_v(); vj++) {
-                  Point control_point = get_control_point(ui, vj);
-                 const auto dist = (p - control_point).squaredNorm();
-                 cout << dist << ", " << min_dist << endl;
-                 //cout << "dist < min_dist: " << int(dist < min_dist )<< endl;
 
-                 if(dist < min_dist){
-                     min_dist = dist;
-                     i_min = ui;
-                     j_min = vj;
+        ThisType subpatch(Scalar u_min, Scalar u_max, Scalar v_min,
+                          Scalar v_max) const {
+          const auto c = m_homogeneous.subpatch(u_min, u_max, v_min, v_max);
+          ThisType result;
+          result.set_homogeneous(c);
+          return result;
+        }
 
-                 }
-              }
-            }
-            if (level <= 0) {
-                return get_control_point_preimage(i_min, j_min);
+        UVPoint approximate_inverse_evaluate(const Point &p, const int num_samples,
+                                     const Scalar min_u, const Scalar max_u,
+                                     const Scalar min_v, const Scalar max_v,
+                                     const int level = 3) const override {
 
-            } else {
+          // Only two control points at the endpoints, so finding the closest
+          // point doesn't restrict the search at all; default to the parent
+          // class function based on sampling where resolution isn't an issue
+          if (Base::get_degree_u() < 2 || Base::get_degree_v() < 2) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u,
+                                                      max_u, min_v, max_v);
+          }
 
-            // Control points c_{i+/-1,j+/-1} bound the domain
-            // 2. find subdomain corresponding to control point subdomain boundary
+          // 1. find closest control point
+          auto closest_control_pt_index = Base::find_closest_control_point(p);
+          int i_min = closest_control_pt_index.first;
+          int j_min = closest_control_pt_index.second;
+
+          if (level <= 0) {
+            return get_control_point_preimage(i_min, j_min);
+
+          } else {
+            // 2. Control points c_{i+/-1,j+/-1} bound the domain containing our
+            // desired initial guess; find subdomain corresponding to control
+            // point subdomain boundary
+            // Conditionals for bound checking
             UVPoint uv_min = get_control_point_preimage(
-                    i_min > 0 ? i_min-1: i_min,
-                    j_min > 0 ? j_min-1: j_min);
+                i_min > 0 ? i_min - 1 : i_min, 
+                j_min > 0 ? j_min - 1 : j_min);
             UVPoint uv_max = get_control_point_preimage(
-                    i_min < num_control_points_u() ? i_min+1 : i_min,
-                    j_min < num_control_points_v() ? j_min+1 : j_min);
-            cout << "min, max:  " << uv_min << ", " << uv_max << endl;
-            // 3. split curve to find ctrl points on subdomain
-            // TODO implement patch split in parent class
-            
+                i_min < num_control_points_u() - 1 ? i_min + 1 : i_min,
+                j_min < num_control_points_v() - 1 ? j_min + 1 : j_min);
+
+            // 3. split a subcurve to find closest ctrl points on subdomain
+            ThisType patch = subpatch(uv_min(0), uv_max(0), uv_min(1), uv_max(1));
             // repeat recursively
-            // TODO remap solution up through affine subdomain transformations
-                return approximate_inverse_evaluate(p, num_samples,
-                        std::max(uv_min(0), min_u),
-                        std::min(uv_max(0), max_u),
-                        std::max(uv_min(1), min_v),
-                        std::min(uv_max(1), max_v),
-                        level-1);
-            }
+            UVPoint uv = patch.approximate_inverse_evaluate(p, num_samples, 
+                    uv_min(0), uv_max(0), uv_min(1), uv_max(1), level - 1);
 
+            // no need to remap coordinates for splines
 
+            return uv;
+          }
         }
 
     private:

--- a/include/nanospline/NURBSPatch.h
+++ b/include/nanospline/NURBSPatch.h
@@ -15,6 +15,7 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
 
         using Base = PatchBase<_Scalar, _dim>;
         using Scalar = typename Base::Scalar;
+        using UVPoint = typename Base::UVPoint;
         using Point = typename Base::Point;
         using ControlGrid = typename Base::ControlGrid;
         using ThisType = NURBSPatch<_Scalar, _dim, _degree_u, _degree_v>;
@@ -34,9 +35,15 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
         int num_control_points_u() const override {
             return m_homogeneous.num_control_points_u();
         }
+        
         int num_control_points_v() const override {
             return m_homogeneous.num_control_points_v();
         }
+
+        UVPoint get_control_point_preimage(int i, int j) const override {
+            return m_homogeneous.get_control_point_preimage(i, j);
+        }
+
         Point get_control_point(int i, int j) const override {
             Eigen::Matrix<Scalar, 1, _dim+1> control_point = m_homogeneous.get_control_point(i,j);
             return control_point.head(_dim);
@@ -280,6 +287,61 @@ class NURBSPatch final : public PatchBase<_Scalar, _dim> {
                 results.back().set_homogeneous(c);
             }
             return results;
+
+        }
+        UVPoint approximate_inverse_evaluate(const Point& p,
+                const int num_samples,
+                const Scalar min_u,
+                const Scalar max_u,
+                const Scalar min_v,
+                const Scalar max_v,
+                const int level=3) const {
+            
+            // 1. find closest control point
+            Scalar min_dist = std::numeric_limits<Scalar>::max();
+            int i_min, j_min;
+            for (int ui = 0; ui < num_control_points_u(); ui++) {
+              for (int vj = 0; vj < num_control_points_v(); vj++) {
+                  Point control_point = get_control_point(ui, vj);
+                 const auto dist = (p - control_point).squaredNorm();
+                 cout << dist << ", " << min_dist << endl;
+                 //cout << "dist < min_dist: " << int(dist < min_dist )<< endl;
+
+                 if(dist < min_dist){
+                     min_dist = dist;
+                     i_min = ui;
+                     j_min = vj;
+
+                 }
+              }
+            }
+            if (level <= 0) {
+                return get_control_point_preimage(i_min, j_min);
+
+            } else {
+
+            // Control points c_{i+/-1,j+/-1} bound the domain
+            // 2. find subdomain corresponding to control point subdomain boundary
+            UVPoint uv_min = get_control_point_preimage(
+                    i_min > 0 ? i_min-1: i_min,
+                    j_min > 0 ? j_min-1: j_min);
+            UVPoint uv_max = get_control_point_preimage(
+                    i_min < num_control_points_u() ? i_min+1 : i_min,
+                    j_min < num_control_points_v() ? j_min+1 : j_min);
+            cout << "min, max:  " << uv_min << ", " << uv_max << endl;
+            // 3. split curve to find ctrl points on subdomain
+            // TODO implement patch split in parent class
+            
+            // repeat recursively
+            // TODO remap solution up through affine subdomain transformations
+                return approximate_inverse_evaluate(p, num_samples,
+                        std::max(uv_min(0), min_u),
+                        std::min(uv_max(0), max_u),
+                        std::max(uv_min(1), min_v),
+                        std::min(uv_max(1), max_v),
+                        level-1);
+            }
+
 
         }
 

--- a/include/nanospline/PatchBase.h
+++ b/include/nanospline/PatchBase.h
@@ -53,7 +53,7 @@ class PatchBase {
                 std::numeric_limits<Scalar>::epsilon() * 100;
             const int num_samples = std::max(m_degree_u, m_degree_v) + 1;
             UVPoint uv = approximate_inverse_evaluate(p, num_samples,
-                    min_u, max_u, min_v, max_v, 8);
+                    min_u, max_u, min_v, max_v, 10);
             return newton_raphson(p, uv, 20, TOL,
                     min_u, max_u, min_v, max_v);
         }

--- a/include/nanospline/PatchBase.h
+++ b/include/nanospline/PatchBase.h
@@ -4,7 +4,8 @@
 #include <cassert>
 #include <Eigen/Core>
 #include <nanospline/Exceptions.h>
-
+#include <iostream>
+using namespace std;
 namespace nanospline {
 
 template<typename _Scalar, int _dim>
@@ -198,14 +199,13 @@ class PatchBase {
             Scalar u = uv[0];
             Scalar v = uv[1];
             UVPoint prev_uv = uv;
-            //Scalar prev_dist = std::numeric_limits<Scalar>::max();
+            Scalar prev_dist = std::numeric_limits<Scalar>::max();
             for (int i=0; i<num_iterations; i++) {
                 const Point r = this->evaluate(u, v) - p;
                 const Scalar dist = r.norm();
                 if (dist < tol) {
                     break;
                 }
-                /*
                  // Converges ok if left alone, could be a result of a poor
                  // initial guess
                 if (dist > prev_dist) {
@@ -213,8 +213,7 @@ class PatchBase {
                     // Use the best result so far.
                     return prev_uv;
                 }
-                //prev_dist = dist;
-                */
+                prev_dist = dist;
                 prev_uv = {u, v};
 
                 const Point Su = this->evaluate_derivative_u(u, v);

--- a/include/nanospline/RationalBezierPatch.h
+++ b/include/nanospline/RationalBezierPatch.h
@@ -30,10 +30,10 @@ class RationalBezierPatch final : public PatchBase<_Scalar, _dim> {
         }
 
     public:
-        int num_control_points_u() const {
+        int num_control_points_u() const override {
             return m_homogeneous.num_control_points_u();
         }
-        int num_control_points_v() const {
+        int num_control_points_v() const override {
             return m_homogeneous.num_control_points_v();
         }
         Point get_control_point(int i, int j) const override {

--- a/include/nanospline/RationalBezierPatch.h
+++ b/include/nanospline/RationalBezierPatch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Eigen/Core>
 #include <nanospline/PatchBase.h>
 #include <nanospline/RationalBezier.h>
 #include <nanospline/BezierPatch.h>
@@ -29,6 +30,17 @@ class RationalBezierPatch final : public PatchBase<_Scalar, _dim> {
         }
 
     public:
+        int num_control_points_u() const {
+            return m_homogeneous.num_control_points_u();
+        }
+        int num_control_points_v() const {
+            return m_homogeneous.num_control_points_v();
+        }
+        Point get_control_point(int i, int j) const override {
+            Eigen::Matrix<Scalar, 1, _dim+1> control_point = m_homogeneous.get_control_point(i,j);
+            return control_point.head(_dim);
+        }
+
         Point evaluate(Scalar u, Scalar v) const override {
             validate_initialization();
             const auto p = m_homogeneous.evaluate(u, v);

--- a/include/nanospline/split.h
+++ b/include/nanospline/split.h
@@ -2,16 +2,34 @@
 
 #include <vector>
 
+#include "nanospline/PatchBase.h"
 #include <nanospline/Exceptions.h>
 #include <nanospline/Bezier.h>
 #include <nanospline/RationalBezier.h>
 #include <nanospline/BSpline.h>
 #include <nanospline/NURBS.h>
-
+using std::cout;
+using std::endl;
 namespace nanospline {
 
 template<typename Scalar, int dim, int degree, bool generic>
 std::vector<Bezier<Scalar, dim, degree, generic>> split(const Bezier<Scalar, dim, degree, generic>& curve, Scalar t) {
+    using CurveType = Bezier<Scalar, dim, degree, generic>;
+    if(!curve.in_domain(t)) {
+        throw invalid_setting_error("Parameter not inside of the domain.");
+    }
+    if (t == curve.get_domain_lower_bound()) {
+        return std::vector<CurveType>{curve};
+//        std::vector<CurveType> results;
+//        results.push_back(curve);
+//        return results;
+    }
+    if (t == curve.get_domain_upper_bound()) {
+        return std::vector<CurveType>{curve};
+//        std::vector<CurveType> results;
+//        results.push_back(curve);
+//        return results;
+    }
     auto r = curve.split(t);
     return {r[0], r[1]};
 }
@@ -21,9 +39,15 @@ std::vector<RationalBezier<Scalar, dim, degree, generic>> split(const RationalBe
     using CurveType = RationalBezier<Scalar, dim, degree, generic>;
     const auto homogeneous = curve.get_homogeneous();
     const auto parts = split(homogeneous, t);
-    std::vector<CurveType> results(2);
-    results[0].set_homogeneous(parts[0]);
-    results[1].set_homogeneous(parts[1]);
+    //std::vector<CurveType> results(2);
+    //results[0].set_homogeneous(parts[0]);
+    //results[1].set_homogeneous(parts[1]);
+    std::vector<CurveType> results;
+    results.reserve(2);
+    for (const auto& c : parts) {
+        results.emplace_back();
+        results.back().set_homogeneous(c);
+    }
     return results;
 }
 
@@ -94,5 +118,4 @@ std::vector<NURBS<Scalar, dim, degree, generic>> split(NURBS<Scalar, dim, degree
     }
     return results;
 }
-
 }

--- a/include/nanospline/split.h
+++ b/include/nanospline/split.h
@@ -33,9 +33,6 @@ std::vector<RationalBezier<Scalar, dim, degree, generic>> split(const RationalBe
     using CurveType = RationalBezier<Scalar, dim, degree, generic>;
     const auto homogeneous = curve.get_homogeneous();
     const auto parts = split(homogeneous, t);
-    //std::vector<CurveType> results(2);
-    //results[0].set_homogeneous(parts[0]);
-    //results[1].set_homogeneous(parts[1]);
     std::vector<CurveType> results;
     results.reserve(2);
     for (const auto& c : parts) {

--- a/include/nanospline/split.h
+++ b/include/nanospline/split.h
@@ -20,15 +20,9 @@ std::vector<Bezier<Scalar, dim, degree, generic>> split(const Bezier<Scalar, dim
     }
     if (t == curve.get_domain_lower_bound()) {
         return std::vector<CurveType>{curve};
-//        std::vector<CurveType> results;
-//        results.push_back(curve);
-//        return results;
     }
     if (t == curve.get_domain_upper_bound()) {
         return std::vector<CurveType>{curve};
-//        std::vector<CurveType> results;
-//        results.push_back(curve);
-//        return results;
     }
     auto r = curve.split(t);
     return {r[0], r[1]};

--- a/include/nanospline/split.h
+++ b/include/nanospline/split.h
@@ -8,8 +8,7 @@
 #include <nanospline/RationalBezier.h>
 #include <nanospline/BSpline.h>
 #include <nanospline/NURBS.h>
-using std::cout;
-using std::endl;
+
 namespace nanospline {
 
 template<typename Scalar, int dim, int degree, bool generic>

--- a/tests/test_BSplinePatch.cpp
+++ b/tests/test_BSplinePatch.cpp
@@ -63,7 +63,8 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         patch.set_control_grid(control_grid);
         Eigen::Matrix<Scalar, 8, 1> knots_u, knots_v;
         knots_u << 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0;
-        knots_v << 0.0, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 2.5;
+        knots_v << 0.0, 0.0, 0.0, 0.0, 2.5, 2.5, 2.5, 2.5;
+        //knots_v << 0.0, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 2.5;
         patch.set_knots_u(knots_u);
         patch.set_knots_v(knots_v);
         patch.initialize();
@@ -74,7 +75,28 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         validate_inverse_evaluation(patch, 10, 10);
         validate_inverse_evaluation_3d(patch, 5,5);
     }
+    SECTION("Cubic spline") {
+        BSplinePatch<Scalar, 3, 3, 3> patch;
+        Eigen::Matrix<Scalar, 64, 3> control_grid;
+        for (int i=0; i<8; i++) {
+            for (int j=0; j<8; j++) {
+                control_grid.row(i*8+j) << j, i, ((i+j)%2==0)?-1:1;
+            }
+        }
+        patch.set_control_grid(control_grid);
+        Eigen::Matrix<Scalar, 12, 1> knots_u, knots_v;
+        knots_u << 0.0, 0.0, 0.0, 0.0, .25, .5, .75, .9, 1.0, 1.0, 1.0, 1.0;
+        knots_v << 0.0, 0.0, 0.0, 0.0, .25, 1., 1.5, 1.9, 2.5, 2.5, 2.5, 2.5;
+        patch.set_knots_u(knots_u);
+        patch.set_knots_v(knots_v);
+        patch.initialize();
 
+//        validate_iso_curves(patch, 10);
+//        validate_derivative(patch, 10, 10);
+//        validate_derivative_patches(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10,10);
+    }
     SECTION("Degree 1 patch") {
         BSplinePatch<Scalar, 3, -1, -1> patch;
         Eigen::Matrix<Scalar, Eigen::Dynamic, 3> control_grid(4, 3);

--- a/tests/test_BSplinePatch.cpp
+++ b/tests/test_BSplinePatch.cpp
@@ -49,7 +49,7 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
-        validate_inverse_evaluation_3d(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 5, 5);
     }
 
     SECTION("Cubic patch") {
@@ -72,7 +72,7 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
-        validate_inverse_evaluation_3d(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 5,5);
     }
 
     SECTION("Degree 1 patch") {
@@ -99,7 +99,7 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
-        //validate_inverse_evaluation_3d(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 5, 5);
     }
 
     SECTION("Mixed degree") {

--- a/tests/test_BSplinePatch.cpp
+++ b/tests/test_BSplinePatch.cpp
@@ -91,9 +91,9 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         patch.set_knots_v(knots_v);
         patch.initialize();
 
-//        validate_iso_curves(patch, 10);
-//        validate_derivative(patch, 10, 10);
-//        validate_derivative_patches(patch, 10, 10);
+        validate_iso_curves(patch, 10);
+        validate_derivative(patch, 10, 10);
+        validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
         validate_inverse_evaluation_3d(patch, 10,10);
     }

--- a/tests/test_BSplinePatch.cpp
+++ b/tests/test_BSplinePatch.cpp
@@ -49,6 +49,7 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Cubic patch") {
@@ -71,6 +72,7 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Degree 1 patch") {
@@ -97,6 +99,7 @@ TEST_CASE("BSplinePatch", "[nonrational][bspline_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        //validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Mixed degree") {

--- a/tests/test_BezierPatch.cpp
+++ b/tests/test_BezierPatch.cpp
@@ -44,7 +44,6 @@ TEST_CASE("BeizerPatch", "[nonrational][bezier_patch]") {
         validate_inverse_evaluation(patch, 10, 10);
         validate_inverse_evaluation_3d(patch, 10, 10);
     }
-
     SECTION("Bilinear patch non-planar") {
         BezierPatch<Scalar, 3, 1, 1> patch;
         Eigen::Matrix<Scalar, 4, 3> control_grid;
@@ -73,13 +72,12 @@ TEST_CASE("BeizerPatch", "[nonrational][bezier_patch]") {
         REQUIRE(p_mid[1] == Approx(0.5));
         REQUIRE(p_mid[2] == Approx(0.5));
 
-        validate_iso_curves(patch, 10);
-        validate_derivative(patch, 10, 10);
-        validate_derivative_patches(patch, 10, 10);
+        //validate_iso_curves(patch, 10);
+        //validate_derivative(patch, 10, 10);
+        //validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
         validate_inverse_evaluation_3d(patch, 10, 10);
     }
-
     SECTION("Cubic patch") {
         BezierPatch<Scalar, 3, 3, 3> patch;
         Eigen::Matrix<Scalar, 16, 3> control_grid;

--- a/tests/test_BezierPatch.cpp
+++ b/tests/test_BezierPatch.cpp
@@ -42,6 +42,7 @@ TEST_CASE("BeizerPatch", "[nonrational][bezier_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Bilinear patch non-planar") {
@@ -76,6 +77,7 @@ TEST_CASE("BeizerPatch", "[nonrational][bezier_patch]") {
         validate_derivative(patch, 10, 10);
         validate_derivative_patches(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Cubic patch") {
@@ -102,5 +104,6 @@ TEST_CASE("BeizerPatch", "[nonrational][bezier_patch]") {
         validate_derivative_patches(patch, 10, 10);
         validate_iso_curves(patch, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 }

--- a/tests/test_NURBSPatch.cpp
+++ b/tests/test_NURBSPatch.cpp
@@ -10,7 +10,6 @@
 TEST_CASE("NURBSPatch", "[rational][bspline_patch]") {
     using namespace nanospline;
     using Scalar = double;
-
     SECTION("Bilinear patch non-planar") {
         NURBSPatch<Scalar, 3, 1, 1> patch;
         Eigen::Matrix<Scalar, 4, 3> control_grid;
@@ -66,7 +65,7 @@ TEST_CASE("NURBSPatch", "[rational][bspline_patch]") {
         patch.set_control_grid(control_grid);
         Eigen::Matrix<Scalar, 8, 1> knots_u, knots_v;
         knots_u << 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0;
-        knots_v << 0.0, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 2.5;
+        knots_v << 0.0, 0.0, 0.0, 0.0, 2.5, 2.5, 2.5, 2.5;
         patch.set_knots_u(knots_u);
         patch.set_knots_v(knots_v);
 
@@ -88,6 +87,55 @@ TEST_CASE("NURBSPatch", "[rational][bspline_patch]") {
         validate_derivative(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
         validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+    SECTION("Cubic spline"){
+        // BUG splitting NURBS patches can vary the size of the number of weights of  
+        // the resulting patches, which is templated to match the number of
+        // control points. Needs -1, -1 for degree in order to compile.
+        NURBSPatch<Scalar, 3, -1,-1> patch;
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 3> control_grid(64, 3);
+        for (int i=0; i<8; i++) {
+            for (int j=0; j<8; j++) {
+                control_grid.row(i*8+j) << j, i, ((i+j)%2==0)?-1:1;
+            }
+        }
+        patch.set_control_grid(control_grid);
+        
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> knots_u(12,1); 
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> knots_v(12,1);
+
+        knots_u << 0.0, 0.0, 0.0, 0.0, .25, .5, .75, .9, 1.0, 1.0, 1.0, 1.0;
+        knots_v << 0.0, 0.0, 0.0, 0.0, .25, 1., 1.5, 1.9, 2.5, 2.5, 2.5, 2.5;
+
+        patch.set_knots_u(knots_u);
+        patch.set_knots_v(knots_v);
+
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> weights(64, 1); 
+        weights.setOnes();
+        SECTION("Uniform weight") {
+            weights.setConstant(2.0);
+        }
+        SECTION("Non-uniform weight") {
+          std::random_device rd;
+          std::mt19937 generator(rd());
+          std::uniform_int_distribution<int> dist(0, 63);
+          for (int i = 0; i < 20; i++) {
+            weights[dist(generator)] = 2.;
+          }
+        }
+
+        patch.set_weights(weights);
+        patch.set_degree_u(3);
+        patch.set_degree_v(3);
+        patch.initialize();
+
+        REQUIRE(patch.get_degree_u() == 3);
+        REQUIRE(patch.get_degree_v() == 3);
+
+        validate_iso_curves(patch, 10);
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10,10);
     }
 
     SECTION("Mixed degree") {

--- a/tests/test_NURBSPatch.cpp
+++ b/tests/test_NURBSPatch.cpp
@@ -52,6 +52,7 @@ TEST_CASE("NURBSPatch", "[rational][bspline_patch]") {
 
         validate_derivative(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Cubic patch") {
@@ -86,6 +87,7 @@ TEST_CASE("NURBSPatch", "[rational][bspline_patch]") {
         validate_iso_curves(patch, 10);
         validate_derivative(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Mixed degree") {

--- a/tests/test_RationalBezierPatch.cpp
+++ b/tests/test_RationalBezierPatch.cpp
@@ -44,6 +44,7 @@ TEST_CASE("RationalBezierPatch", "[rational][rational_bezier_patch]") {
 
         validate_derivative(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
     SECTION("Cubic patch") {
@@ -82,6 +83,7 @@ TEST_CASE("RationalBezierPatch", "[rational][rational_bezier_patch]") {
         validate_derivative(patch, 10, 10);
         validate_iso_curves(patch, 10);
         validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
     }
 
 }

--- a/tests/test_split.cpp
+++ b/tests/test_split.cpp
@@ -516,7 +516,6 @@ TEST_CASE("Test patch splitting", "[split][patch]"){
         const int degree_v = 4;
         const int dim = 3;
         const int num_control_pts = (degree_u+1)*(degree_v+1);
-        // TODO bug in Catch preventing a loop to try multiple random patches.
         std::random_device rd;
         std::mt19937 generator(rd());
         std::uniform_real_distribution<Scalar> dist(0, 1);

--- a/tests/test_split.cpp
+++ b/tests/test_split.cpp
@@ -2,6 +2,8 @@
 
 #include <nanospline/split.h>
 #include <nanospline/BezierPatch.h>
+#include <nanospline/RationalBezierPatch.h>
+#include <nanospline/NURBSPatch.h>
 #include <nanospline/BSplinePatch.h>
 #include <nanospline/save_svg.h>
 #include <nanospline/forward_declaration.h>
@@ -510,8 +512,8 @@ TEST_CASE("Test patch splitting", "[split][patch]"){
         validate_bezier_patch_splitting(patch);
     }
     SECTION("Bezier Patch random patches degree 5") {
-        const int degree_u = 3;
-        const int degree_v = 3;
+        const int degree_u = 4;
+        const int degree_v = 4;
         const int dim = 3;
         const int num_control_pts = (degree_u+1)*(degree_v+1);
         // TODO bug in Catch preventing a loop to try multiple random patches.
@@ -682,6 +684,150 @@ TEST_CASE("Test patch splitting", "[split][patch]"){
         patch.initialize();
         validate_bspline_patch_splitting(patch);
     }
+
+    SECTION("RationalBezier cubic patch") {
+      RationalBezierPatch<Scalar, 3, 3, 3> patch;
+      Eigen::Matrix<Scalar, 16, 3> control_grid;
+      for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < 4; j++) {
+          control_grid.row(i * 4 + j) << j, i, ((i + j) % 2 == 0) ? -1 : 1;
+        }
+      }
+      patch.set_control_grid(control_grid);
+
+      Eigen::Matrix<Scalar, 16, 1> weights;
+      SECTION("Uniform weight") {
+        weights.setConstant(1);
+        patch.set_weights(weights);
+        patch.initialize();
+        validate_bezier_patch_splitting(patch);
+      }
+      SECTION("Non-uniform weight") {
+        weights.setConstant(1);
+        weights[5] = 2.0;
+        weights[6] = 2.0;
+        weights[9] = 2.0;
+        weights[10] = 2.0;
+        patch.set_weights(weights);
+        patch.initialize();
+        validate_bezier_patch_splitting(patch);
+      }
+    }
+
+    SECTION("Bilinear patch non-planar") {
+        NURBSPatch<Scalar, 3, 1, 1> patch;
+        Eigen::Matrix<Scalar, 4, 3> control_grid;
+        control_grid <<
+            0.0, 0.0, 0.0,
+            0.0, 1.0, 1.0,
+            1.0, 0.0, 1.0,
+            1.0, 1.0, 0.0;
+        patch.set_control_grid(control_grid);
+
+        Eigen::Matrix<Scalar, 4, 1> weights;
+        weights.setConstant(2.0);
+        patch.set_weights(weights);
+
+        Eigen::Matrix<Scalar, 4, 1> knots_u, knots_v;
+        knots_u << 0.0, 0.0, 1.0, 1.0;
+        knots_v << 0.0, 0.0, 1.0, 1.0;
+        patch.set_knots_u(knots_u);
+        patch.set_knots_v(knots_v);
+
+        patch.initialize();
+            validate_bspline_patch_splitting(patch);
+
+    }
+
+    SECTION("Cubic patch") {
+        NURBSPatch<Scalar, 3, 3, 3> patch;
+        Eigen::Matrix<Scalar, 16, 3> control_grid;
+        for (int i=0; i<4; i++) {
+            for (int j=0; j<4; j++) {
+                control_grid.row(i*4+j) << j, i, ((i+j)%2==0)?-1:1;
+            }
+        }
+        patch.set_control_grid(control_grid);
+        Eigen::Matrix<Scalar, 8, 1> knots_u, knots_v;
+        knots_u << 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0;
+        knots_v << 0.0, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 2.5;
+        patch.set_knots_u(knots_u);
+        patch.set_knots_v(knots_v);
+
+        Eigen::Matrix<Scalar, 16, 1> weights;
+        weights.setOnes();
+        SECTION("Uniform weight") {
+            weights.setConstant(2.0);
+            
+            patch.set_weights(weights);
+            patch.initialize();
+            validate_bspline_patch_splitting(patch);
+        }
+        SECTION("Non-uniform weight") {
+            weights[5] = 2.0;
+            weights[6] = 2.0;
+            weights[9] = 2.0;
+            weights[10] = 2.0;
+            
+            patch.set_weights(weights);
+            patch.initialize();
+            validate_bspline_patch_splitting(patch);
+        }
+
+    }
+
+    SECTION("Mixed degree") {
+        NURBSPatch<Scalar, 3, -1, -1> patch;
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 3> control_grid(14, 3);
+        control_grid << 31.75, 0.0, 12.700000000000001,
+                        31.75, 0.0, 0.0,
+                        31.75, -54.99261314031184, 12.700000000000001,
+                        31.75, -54.99261314031184, 0.0,
+                        -15.874999999999993, -27.49630657015593, 12.700000000000001,
+                        -15.874999999999993, -27.49630657015593, 0.0,
+                        -63.499999999999986, -7.776507174585691e-15, 12.700000000000001,
+                        -63.499999999999986, -7.776507174585691e-15, 0.0,
+                        -15.875000000000014, 27.49630657015592, 12.700000000000001,
+                        -15.875000000000014, 27.49630657015592, 0.0,
+                        31.74999999999995, 54.99261314031187, 12.700000000000001,
+                        31.74999999999995, 54.99261314031187, 0.0,
+                        31.75, 7.776507174585693e-15, 12.700000000000001,
+                        31.75, 7.776507174585693e-15, 0.0;
+        patch.set_control_grid(control_grid);
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> weights(14, 1);
+        weights << 1.0, 1.0,
+                   0.5, 0.5,
+                   1.0, 1.0,
+                   0.5, 0.5,
+                   1.0, 1.0,
+                   0.5, 0.5,
+                   1.0, 1.0;
+        patch.set_weights(weights);
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> u_knots(10, 1);
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> v_knots(4, 1);
+        u_knots << 0.0, 
+                   0.0, 
+                   0.0, 
+                   2.0943951023931953, 
+                   2.0943951023931953, 
+                   4.1887902047863905, 
+                   4.1887902047863905, 
+                   6.283185307179586, 
+                   6.283185307179586, 
+                   6.283185307179586;
+        v_knots << -10.573884999451131, 
+                   -10.573884999451131, 
+                   2.12611500054887, 
+                   2.12611500054887;
+        patch.set_knots_u(u_knots);
+        patch.set_knots_v(v_knots);
+        patch.set_degree_u(2);
+        patch.set_degree_v(1);
+        patch.initialize();
+        validate_bspline_patch_splitting(patch);
+
+    }
+
 }
 
 

--- a/tests/test_split.cpp
+++ b/tests/test_split.cpp
@@ -1,18 +1,107 @@
 #include <catch2/catch.hpp>
 
 #include <nanospline/split.h>
+#include <nanospline/BezierPatch.h>
+#include <nanospline/BSplinePatch.h>
 #include <nanospline/save_svg.h>
 #include <nanospline/forward_declaration.h>
 #include "validation_utils.h"
+#include <iostream>
+template<typename PatchType>
+void validate_patch_splitting(PatchType patch){
+  using Scalar = typename PatchType::Scalar;
+    SECTION("Degenerate split: u,v=(0,0)") {
+        Scalar u = 0.;
+        Scalar v = 0.;
+        const auto subpatches = patch.split(u, v);
+        cout << "num split " << subpatches.size() << endl;
+        assert_same(patch, subpatches[0], 10, 
+                0., 1., 0., 1., 
+                0., 1., 0., 1.);
+    }
 
-TEST_CASE("split", "[split]") {
+    SECTION("Degenerate split: u,v=(1,1)") {
+        Scalar u = 1.;
+        Scalar v = 1.;
+        const auto subpatches = patch.split(u, v);
+        assert_same(patch, subpatches[0], 10, 
+                0., 1., 0., 1., 
+                0., 1., 0., 1.);
+    }
+    SECTION("Degenerate split: u,v=(0,1)") {
+        Scalar u = 0.;
+        Scalar v = 1.;
+        const auto subpatches = patch.split(u, v);
+        assert_same(patch, subpatches[0], 10, 
+                0., 1., 0., 1., 
+                0., 1., 0., 1.);
+    }
+    SECTION("Degenerate split: u,v=(1,0)") {
+        Scalar u = 1.;
+        Scalar v = 0.;
+        const auto subpatches = patch.split(u, v);
+        assert_same(patch, subpatches[0], 10, 
+                0., 1., 0., 1., 
+                0., 1., 0., 1.);
+    }
+
+    SECTION("Split: u=.5") {
+        Scalar u = .5;
+        const auto subpatches = patch.split_u(u);
+        assert_same(patch, subpatches[0], 10, 
+                0., u, 0., 1.,
+                0., 1., 0., 1.);
+        assert_same(patch, subpatches[1], 10, 
+                u, 1., 0., 1.,
+                0., 1., 0., 1.);
+    }
+    SECTION("Split: v=.5") {
+        Scalar v = .5;
+        const auto subpatches = patch.split_v(v);
+        assert_same(patch, subpatches[0], 10, 
+                0., 1., 0., v,
+                0., 1., 0., 1.);
+        assert_same(patch, subpatches[1], 10, 
+                0., 1., v,  1.,
+                0., 1., 0., 1.);
+    }
+    SECTION("Split u,v: random points:"){
+        std::random_device rd;
+        std::mt19937 generator(rd());
+        std::uniform_real_distribution<Scalar> dist(0, 1);
+
+        int num_split_tests = 30;
+        for (int i =0; i < num_split_tests; i++) {
+            Scalar u = dist(generator);
+            Scalar v = dist(generator);
+
+            const auto subpatches = patch.split(u,v);
+            assert_same(patch, subpatches[0], 10, 
+                    0., u, 0., v,
+                    0., 1., 0., 1.);
+            assert_same(patch, subpatches[2], 10, 
+                    u,  1., 0., v,
+                    0., 1., 0., 1.);
+            assert_same(patch, subpatches[1], 10, 
+                    0., u,   v, 1.,
+                    0., 1., 0., 1.);
+
+            assert_same(patch, subpatches[3], 10, 
+                    u,  1.,  v, 1.,
+                    0., 1., 0., 1.);
+        }
+    }
+}
+
+
+TEST_CASE("Test curve splitting", "[split][curve]") {
     using namespace nanospline;
     using Scalar = double;
 
     SECTION("Bezier degree 1") {
         Eigen::Matrix<Scalar, 2, 2> control_pts;
         control_pts << 0.0, 0.0,
-                       1.0, 0.0;
+                    1.0, 0.0;
         Bezier<Scalar, 2, 1, true> curve;
         curve.set_control_points(control_pts);
 
@@ -31,9 +120,9 @@ TEST_CASE("split", "[split]") {
     SECTION("Bezier degree 3") {
         Eigen::Matrix<Scalar, 4, 2> control_pts;
         control_pts << 0.0, 0.0,
-                       1.0, 1.0,
-                       2.0, 1.0,
-                       3.0, 0.0;
+                    1.0, 1.0,
+                    2.0, 1.0,
+                    3.0, 0.0;
         Bezier<Scalar, 2, 3, true> curve;
         curve.set_control_points(control_pts);
 
@@ -52,14 +141,18 @@ TEST_CASE("split", "[split]") {
         }
 
         const auto parts = split(curve, split_location);
-        assert_same(curve, parts[0], 10, 0.0, split_location, 0.0, 1.0);
-        assert_same(curve, parts[1], 10, split_location, 1.0, 0.0, 1.0);
+        if(parts.size() == 2){
+            assert_same(curve, parts[0], 10, 0.0, split_location, 0.0, 1.0);
+            assert_same(curve, parts[1], 10, split_location, 1.0, 0.0, 1.0);
+        } else {
+            assert_same(curve, parts[0], 10);
+        }
     }
 
     SECTION("Rational bezier degree 1") {
         Eigen::Matrix<Scalar, 2, 2> control_pts;
         control_pts << 0.0, 0.0,
-                       1.0, 0.0;
+                    1.0, 0.0;
         Eigen::Matrix<Scalar, 2, 1> weights;
         weights << 0.1, 1.0;
 
@@ -83,16 +176,20 @@ TEST_CASE("split", "[split]") {
         }
 
         const auto parts = split(curve, split_location);
-        assert_same(curve, parts[0], 10, 0.0, split_location, 0.0, 1.0);
-        assert_same(curve, parts[1], 10, split_location, 1.0, 0.0, 1.0);
+        if(parts.size() == 2){
+            assert_same(curve, parts[0], 10, 0.0, split_location, 0.0, 1.0);
+            assert_same(curve, parts[1], 10, split_location, 1.0, 0.0, 1.0);
+        } else {
+            assert_same(curve, parts[0], 10);
+        }
     }
 
     SECTION("Rational bezier degree 3") {
         Eigen::Matrix<Scalar, 4, 2> control_pts;
         control_pts << 0.0, 0.0,
-                       1.0, 1.0,
-                       2.0,-1.0,
-                       3.0, 0.0;
+                    1.0, 1.0,
+                    2.0,-1.0,
+                    3.0, 0.0;
         Eigen::Matrix<Scalar, 4, 1> weights;
         weights << 0.1, 1.0, 0.1, 0.1;
 
@@ -116,8 +213,12 @@ TEST_CASE("split", "[split]") {
         }
 
         const auto parts = split(curve, split_location);
-        assert_same(curve, parts[0], 10, 0.0, split_location, 0.0, 1.0);
-        assert_same(curve, parts[1], 10, split_location, 1.0, 0.0, 1.0);
+        if(parts.size() == 2){
+            assert_same(curve, parts[0], 10, 0.0, split_location, 0.0, 1.0);
+            assert_same(curve, parts[1], 10, split_location, 1.0, 0.0, 1.0);
+        } else {
+            assert_same(curve, parts[0], 10);
+        }
     }
 
     SECTION("BSpline degree 3") {
@@ -143,8 +244,17 @@ TEST_CASE("split", "[split]") {
         SECTION("End") {
             split_location = 1.0;
         }
-
         const auto parts = split(curve, split_location);
+        /*if (split_location == 0.5) {
+        cout << "parent" << endl;
+        cout << curve.get_control_points() << endl;
+
+        cout << "child <.5" << endl;
+        cout << parts[0].get_control_points() << endl;
+        cout << "child >.5 " << endl;
+        cout << parts[1].get_control_points() << endl;
+        exit(0);
+        }*/
         if (split_location == 0.0) {
             REQUIRE(parts.size() == 1);
             assert_same(curve, parts[0], 10);
@@ -160,17 +270,17 @@ TEST_CASE("split", "[split]") {
     SECTION("NURBS degree 2") {
         Eigen::Matrix<Scalar, 8, 2> ctrl_pts;
         ctrl_pts << 0.0, 0.0,
-                    0.0, 1.0,
-                    1.0, 1.0,
-                    1.0, 0.0,
-                    2.0, 0.0,
-                    2.0, 1.0,
-                    3.0, 1.0,
-                    3.0, 0.0;
+                 0.0, 1.0,
+                 1.0, 1.0,
+                 1.0, 0.0,
+                 2.0, 0.0,
+                 2.0, 1.0,
+                 3.0, 1.0,
+                 3.0, 0.0;
         Eigen::Matrix<Scalar, 11, 1> knots;
         knots << 0.0, 0.0, 0.0,
-                 1.0, 2.0, 3.0, 4.0, 5.0,
-                 6.0, 6.0, 6.0;
+              1.0, 2.0, 3.0, 4.0, 5.0,
+              6.0, 6.0, 6.0;
         Eigen::Matrix<Scalar ,8, 1> weights;
         weights << 1.0, 1.0, 1.0, 1.0, 0.5, 0.5, 0.5, 0.5;
 
@@ -258,3 +368,135 @@ TEST_CASE("split", "[split]") {
         }
     }
 }
+TEST_CASE("Test patch splitting", "[split][patch]"){
+  using Scalar = double;
+  using namespace nanospline;
+    SECTION("Bezier Patch degree 3") {
+        using std::cout;
+        using std::endl;
+        const int degree_u = 3;
+        const int degree_v = 3;
+        const int dim = 3;
+        const int num_control_pts = (degree_u+1)*(degree_v+1);
+
+        BezierPatch<Scalar, dim, degree_u, degree_v> patch;
+        Eigen::Matrix<Scalar, num_control_pts, dim> control_grid;
+        for (int i = 0; i <= degree_u; i++) {
+            for (int j = 0; j <= degree_v; j++) {
+                control_grid.row(i * (degree_v+1) + j) << j, i, ((i + j) % 2 == 0) ? -1 : 1;
+            }
+        }
+        patch.set_control_grid(control_grid);
+        patch.initialize();
+        validate_patch_splitting(patch);
+    }
+    SECTION("Bezier Patch random patches degree 5") {
+        const int degree_u = 3;
+        const int degree_v = 3;
+        const int dim = 3;
+        const int num_control_pts = (degree_u+1)*(degree_v+1);
+        // TODO bug in Catch preventing a loop to try multiple random patches.
+        std::random_device rd;
+        std::mt19937 generator(rd());
+        std::uniform_real_distribution<Scalar> dist(0, 1);
+        
+        BezierPatch<Scalar, dim, degree_u, degree_v> patch;
+        Eigen::Matrix<Scalar, num_control_pts, dim> control_grid;
+        for (int i = 0; i <= degree_u; i++) {
+            for (int j = 0; j <= degree_v; j++) {
+                control_grid.row(i * (degree_v+1) + j) << dist(generator), dist(generator),dist(generator);
+            }
+        }
+       
+        patch.set_control_grid(control_grid);
+        patch.initialize();
+        //validate_patch_splitting(patch);
+    }
+    SECTION("Bezier Patch mixed degree") {
+        using std::cout;
+        using std::endl;
+        const int degree_u = 3;
+        const int degree_v = 5;
+        const int dim = 3;
+        const int num_control_pts = (degree_u+1)*(degree_v+1);
+
+        BezierPatch<Scalar, dim, degree_u, degree_v> patch;
+        Eigen::Matrix<Scalar, num_control_pts, dim> control_grid;
+        for (int i = 0; i <= degree_u; i++) {
+            for (int j = 0; j <= degree_v; j++) {
+                control_grid.row(i * (degree_v+1) + j) << j, i, ((i + j) % 2 == 0) ? -1 : 1;
+            }
+        }
+        patch.set_control_grid(control_grid);
+        patch.initialize();
+        //validate_patch_splitting(patch);
+    }
+    SECTION("Bilinear patch non-planar") {
+        BSplinePatch<Scalar, 3, 1, 1> patch;
+        Eigen::Matrix<Scalar, 4, 3> control_grid;
+        control_grid <<
+            0.0, 0.0, 0.0,
+            0.0, 1.0, 1.0,
+            1.0, 0.0, 1.0,
+            1.0, 1.0, 0.0;
+        patch.set_control_grid(control_grid);
+
+        Eigen::Matrix<Scalar, 4, 1> knots_u, knots_v;
+        knots_u << 0.0, 0.0, 1.0, 1.0;
+        knots_v << 0.0, 0.0, 1.0, 1.0;
+        patch.set_knots_u(knots_u);
+        patch.set_knots_v(knots_v);
+        patch.initialize();
+
+        //validate_patch_splitting(patch);
+    SECTION("Split: u=.5") {
+        Scalar u = .5;
+        const auto subpatches = patch.split_u(u);
+        assert_same(patch, subpatches[0], 10, 
+                0., u, 0., 1.,
+                0., u, 0., 1.);
+        assert_same(patch, subpatches[1], 10, 
+                u, 1., 0., 1.,
+                u, 1., 0., 1.);
+    }
+    SECTION("Split u,v: random points:"){
+        std::random_device rd;
+        std::mt19937 generator(rd());
+        std::uniform_real_distribution<Scalar> dist(0, 1);
+
+        int num_split_tests = 30;
+        for (int i =0; i < num_split_tests; i++) {
+            Scalar u = dist(generator);
+            Scalar v = dist(generator);
+
+            const auto subpatches = patch.split(u,v);
+            assert_same(patch, subpatches[0], 10, 
+                    0., u, 0., v,
+                    0., u, 0., v);
+            assert_same(patch, subpatches[2], 10, 
+                    u,  1., 0., v,
+                    u, 1., 0., v);
+            assert_same(patch, subpatches[1], 10, 
+                    0., u,   v, 1.,
+                    0., u, v, 1.);
+
+            assert_same(patch, subpatches[3], 10, 
+                    u,  1.,  v, 1.,
+                    u, 1., v, 1.);
+        }
+    }
+    SECTION("Split: v=.5") {
+        Scalar v = .5;
+        const auto subpatches = patch.split_v(v);
+        assert_same(patch, subpatches[0], 10, 
+                0., 1., 0., v,
+                0., 1., 0., v);
+        assert_same(patch, subpatches[1], 10, 
+                0., 1., v,  1.,
+                0., 1., v, 1.);
+    }
+    
+    }
+}
+
+

--- a/tests/test_split.cpp
+++ b/tests/test_split.cpp
@@ -684,7 +684,25 @@ TEST_CASE("Test patch splitting", "[split][patch]"){
         patch.initialize();
         validate_bspline_patch_splitting(patch);
     }
+   
+    SECTION("Cubic spline") {
+        BSplinePatch<Scalar, 3, 3, 3> patch;
+        Eigen::Matrix<Scalar, 64, 3> control_grid;
+        for (int i=0; i<8; i++) {
+            for (int j=0; j<8; j++) {
+                control_grid.row(i*8+j) << j, i, ((i+j)%2==0)?-1:1;
+            }
+        }
+        patch.set_control_grid(control_grid);
+        Eigen::Matrix<Scalar, 12, 1> knots_u, knots_v;
+        knots_u << 0.0, 0.0, 0.0, 0.0, .25, .5, .75, .9, 1.0, 1.0, 1.0, 1.0;
+        knots_v << 0.0, 0.0, 0.0, 0.0, .25, 1., 1.5, 1.9, 2.5, 2.5, 2.5, 2.5;
+        patch.set_knots_u(knots_u);
+        patch.set_knots_v(knots_v);
+        patch.initialize();
+        validate_bspline_patch_splitting(patch);
 
+    }
     SECTION("RationalBezier cubic patch") {
       RationalBezierPatch<Scalar, 3, 3, 3> patch;
       Eigen::Matrix<Scalar, 16, 3> control_grid;
@@ -827,7 +845,6 @@ TEST_CASE("Test patch splitting", "[split][patch]"){
         validate_bspline_patch_splitting(patch);
 
     }
-
 }
 
 

--- a/tests/validation_utils.h
+++ b/tests/validation_utils.h
@@ -399,7 +399,7 @@ void validate_inverse_evaluation(const PatchType& patch,
             const auto q = patch.evaluate(u, v);
             const auto uv = patch.inverse_evaluate(q, u_min, u_max, v_min, v_max);
             const auto p = patch.evaluate(uv[0], uv[1]);
-            REQUIRE((p-q).norm() == Approx(0.0).margin(1e-12));
+            REQUIRE((p-q).norm() == Approx(0.0).margin(1e-13));
         }
     }
 
@@ -428,7 +428,7 @@ void validate_inverse_evaluation_3d(const PatchType& patch,
             auto true_uv(uv);
             true_uv[0] = u;
             true_uv[1] = v;
-            REQUIRE((p-q).norm() == Approx(0.05).margin(1e-11));
+            REQUIRE((p-q).norm() == Approx(0.05).margin(1e-13));
             REQUIRE((true_uv - uv).norm() == Approx(0.0).margin(1e-8));
         }
     }

--- a/tests/validation_utils.h
+++ b/tests/validation_utils.h
@@ -3,9 +3,6 @@
 #include <catch2/catch.hpp>
 #include <limits>
 #include <nanospline/hodograph.h>
-#include <iostream>
-using std::cout;
-using std::endl;
 
 namespace nanospline {
 
@@ -130,7 +127,6 @@ void validate_derivatives(const CurveType& curve, int num_samples,
             const auto diff = t1-t0;
             auto p0 = curve.evaluate(t0);
             auto p1 = curve.evaluate(t1);
-            //std::cout << d*diff << " : " << p1-p0 << std::endl;
             REQUIRE(d[0]*diff == Approx(p1[0]-p0[0]).margin(tol));
             REQUIRE(d[1]*diff == Approx(p1[1]-p0[1]).margin(tol));
         }

--- a/tests/validation_utils.h
+++ b/tests/validation_utils.h
@@ -428,8 +428,8 @@ void validate_inverse_evaluation_3d(const PatchType& patch,
             auto true_uv(uv);
             true_uv[0] = u;
             true_uv[1] = v;
-            REQUIRE((p-q).norm() == Approx(0.05).margin(1e-15));
-            REQUIRE((true_uv - uv).norm() == Approx(0.0).margin(1e-14));
+            REQUIRE((p-q).norm() == Approx(0.05).margin(1e-11));
+            REQUIRE((true_uv - uv).norm() == Approx(0.0).margin(1e-8));
         }
     }
 


### PR DESCRIPTION
Added split_u(), split_v(), split() and subpatch() for each PatchType.
Added approximate_inverse_evaluate() using recursive closest control point distance checks and patch splitting instead of patch sampling. 