### PR TITLE
More periodic tests and refactoring

### DIFF
--- a/include/nanospline/BSpline.h
+++ b/include/nanospline/BSpline.h
@@ -410,7 +410,9 @@ public:
             beziers2.push_back(curve.elevate_degree());
         });
 
-        return TargetType(beziers2, parameter_bounds);
+        TargetType new_curve(beziers2, parameter_bounds);
+        new_curve.set_periodic(Base::get_periodic());
+        return new_curve;
     }
 
     static Eigen::MatrixXd form_least_squares_matrix(

--- a/include/nanospline/BSplineBase.h
+++ b/include/nanospline/BSplineBase.h
@@ -286,9 +286,6 @@ public:
 public:
     int locate_span(Scalar t) const
     {
-        if (Base::get_periodic()) {
-            t = Base::unwrap_parameter(t);
-        }
         const auto p = get_degree();
         const auto num_knots = m_knots.rows();
         assert(num_knots > m_control_points.rows());

--- a/include/nanospline/BSplinePatch.h
+++ b/include/nanospline/BSplinePatch.h
@@ -55,38 +55,6 @@ public:
         Base::set_degree_v(_degree_v);
     }
 
-    BSplinePatch(const ThisType& other)
-        : PatchBase<_Scalar, _dim>(other)
-        , m_knots_u(other.m_knots_u)
-        , m_knots_v(other.m_knots_v)
-    {}
-
-    BSplinePatch(ThisType&& other)
-        : PatchBase<_Scalar, _dim>(other)
-        , m_knots_u(std::move(other.m_knots_u))
-        , m_knots_v(std::move(other.m_knots_v))
-    {}
-
-    ThisType& operator=(const ThisType& other)
-    {
-        Base::m_control_grid = other.m_control_grid;
-        Base::m_degree_u = other.m_degree_u;
-        Base::m_degree_v = other.m_degree_v;
-        m_knots_u = other.m_knots_u;
-        m_knots_v = other.m_knots_v;
-        return *this;
-    }
-
-    ThisType& operator=(ThisType&& other)
-    {
-        swap_control_grid(other.m_control_grid);
-        Base::m_degree_u = other.m_degree_u;
-        Base::m_degree_v = other.m_degree_v;
-        m_knots_u.swap(other.m_knots_u);
-        m_knots_v.swap(other.m_knots_v);
-        return *this;
-    }
-
     std::unique_ptr<Base> clone() const override {
         return std::make_unique<ThisType>(*this);
     }
@@ -139,6 +107,9 @@ public:
         const auto num_u_knots = m_knots_u.size();
         const int degree_u = Base::get_degree_u();
         const int degree_v = Base::get_degree_v();
+        if (degree_u < 0 || degree_v < 0) {
+            throw invalid_setting_error("Patch uv degrees are not set.");
+        }
         if (Base::m_control_grid.rows() !=
             (num_u_knots - degree_u - 1) * (num_v_knots - degree_v - 1)) {
             throw invalid_setting_error("Control grid size mismatch uv degrees");

--- a/include/nanospline/BSplinePatch.h
+++ b/include/nanospline/BSplinePatch.h
@@ -613,6 +613,11 @@ public:
         const Scalar max_v,
         const int level = 15) const override
     {
+        // Use bisection for periodic patches.
+        if (Base::get_periodic_u() || Base::get_periodic_v()) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
+        }
+
         // Only two control points at the endpoints, so finding the closest
         // point doesn't restrict the search at all; default to the parent
         // class function based on sampling where resolution isn't an issue

--- a/include/nanospline/Bezier.h
+++ b/include/nanospline/Bezier.h
@@ -322,6 +322,7 @@ public:
 
         TargetType new_curve;
         new_curve.set_control_points(std::move(target_ctrl_pts));
+        new_curve.set_periodic(Base::get_periodic());
         return new_curve;
     }
 
@@ -471,6 +472,7 @@ public:
         ctrl_pts.row(0) = Base::m_control_points.row(0);
         ctrl_pts.row(1) = Base::m_control_points.row(0);
         new_curve.set_control_points(std::move(ctrl_pts));
+        new_curve.set_periodic(Base::get_periodic());
         return new_curve;
     }
 };
@@ -538,6 +540,7 @@ public:
         ctrl_pts.row(1) = Base::m_control_points.colwise().mean();
         ctrl_pts.row(2) = Base::m_control_points.row(1);
         new_curve.set_control_points(std::move(ctrl_pts));
+        new_curve.set_periodic(Base::get_periodic());
         return new_curve;
     }
 
@@ -727,6 +730,7 @@ public:
             Base::m_control_points.row(1) * 2.0 / 3.0 + Base::m_control_points.row(2) / 3.0;
         ctrl_pts.row(3) = Base::m_control_points.row(2);
         new_curve.set_control_points(std::move(ctrl_pts));
+        new_curve.set_periodic(Base::get_periodic());
         return new_curve;
     }
 
@@ -1017,6 +1021,7 @@ public:
             Base::m_control_points.row(2) * 3.0 / 4.0 + Base::m_control_points.row(3) / 4.0;
         ctrl_pts.row(4) = Base::m_control_points.row(3);
         new_curve.set_control_points(std::move(ctrl_pts));
+        new_curve.set_periodic(Base::get_periodic());
         return new_curve;
     }
 };

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -499,6 +499,11 @@ public:
         const Scalar max_v,
         const int level = 15) const override
     {
+        // Use bisection for periodic patches.
+        if (Base::get_periodic_u() || Base::get_periodic_v()) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
+        }
+
         // Only two control points at the endpoints, so finding the closest
         // point doesn't restrict the search at all; default to the parent
         // class function based on sampling where resolution isn't an issue

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -41,30 +41,6 @@ public:
         Base::set_degree_v(_degree_v);
     }
 
-    BezierPatch(const ThisType& other)
-        : PatchBase<_Scalar, _dim>(other)
-    {}
-
-    BezierPatch(ThisType&& other)
-        : PatchBase<_Scalar, _dim>(std::move(other))
-    {}
-
-    ThisType& operator=(const ThisType& other)
-    {
-        Base::m_control_grid = other.m_control_grid;
-        Base::m_degree_u = other.m_degree_u;
-        Base::m_degree_v = other.m_degree_v;
-        return *this;
-    }
-
-    ThisType& operator=(ThisType&& other)
-    {
-        swap_control_grid(other.m_control_grid);
-        Base::m_degree_u = other.m_degree_u;
-        Base::m_degree_v = other.m_degree_v;
-        return *this;
-    }
-
     std::unique_ptr<Base> clone() const override {
         return std::make_unique<ThisType>(*this);
     }
@@ -115,6 +91,9 @@ public:
     {
         const int degree_u = Base::get_degree_u();
         const int degree_v = Base::get_degree_v();
+        if (degree_u < 0 || degree_v < 0) {
+            throw invalid_setting_error("Patch uv degrees are not set.");
+        }
         if (Base::m_control_grid.rows() != (degree_u + 1) * (degree_v + 1)) {
             throw invalid_setting_error("Control grid size mismatch uv degrees");
         }

--- a/include/nanospline/NURBSPatch.h
+++ b/include/nanospline/NURBSPatch.h
@@ -335,6 +335,11 @@ public:
         const Scalar max_v,
         const int level = 3) const override
     {
+        // Use bisection for periodic patches.
+        if (Base::get_periodic_u() || Base::get_periodic_v()) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
+        }
+
         // Only two control points at the endpoints, so finding the closest
         // point doesn't restrict the search at all; default to the parent
         // class function based on sampling where resolution isn't an issue

--- a/include/nanospline/NURBSPatch.h
+++ b/include/nanospline/NURBSPatch.h
@@ -276,8 +276,10 @@ public:
             ctrl_pts.template leftCols<_dim>().array().colwise() / m_weights.array();
         m_knots_u = homogeneous.get_knots_u();
         m_knots_v = homogeneous.get_knots_v();
-        Base::m_degree_u = homogeneous.get_degree_u();
-        Base::m_degree_v = homogeneous.get_degree_v();
+        Base::set_degree_u(homogeneous.get_degree_u());
+        Base::set_degree_v(homogeneous.get_degree_v());
+        Base::set_periodic_u(homogeneous.get_periodic_u());
+        Base::set_periodic_v(homogeneous.get_periodic_v());
         validate_initialization();
     }
 
@@ -380,6 +382,15 @@ private:
         const auto& ctrl_pts = m_homogeneous.get_control_grid();
         if (ctrl_pts.rows() != Base::m_control_grid.rows() || ctrl_pts.rows() != m_weights.rows()) {
             throw invalid_setting_error("NURBS patch is not initialized.");
+        }
+        if (Base::get_degree_u() < 0 || Base::get_degree_v() < 0) {
+            throw invalid_setting_error("NURBS patch degrees are not initialized.");
+        }
+        if (m_homogeneous.get_periodic_u() != Base::get_periodic_u()) {
+            throw invalid_setting_error("NURBS patch is inconsistent in u periodicity.");
+        }
+        if (m_homogeneous.get_periodic_v() != Base::get_periodic_v()) {
+            throw invalid_setting_error("NURBS patch is inconsistent in v periodicity.");
         }
     }
 

--- a/include/nanospline/RationalBezierPatch.h
+++ b/include/nanospline/RationalBezierPatch.h
@@ -300,6 +300,11 @@ public:
         const Scalar max_v,
         const int level = 3) const override
     {
+        // Use bisection for periodic patches.
+        if (Base::get_periodic_u() || Base::get_periodic_v()) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
+        }
+
         // Only two control points at the endpoints, so finding the closest
         // point doesn't restrict the search at all; default to the parent
         // class function based on sampling where resolution isn't an issue

--- a/include/nanospline/RationalBezierPatch.h
+++ b/include/nanospline/RationalBezierPatch.h
@@ -157,6 +157,8 @@ public:
         m_weights = ctrl_pts.template rightCols<1>();
         Base::m_control_grid =
             ctrl_pts.template leftCols<_dim>().array().colwise() / m_weights.array();
+        Base::set_periodic_u(homogeneous.get_periodic_u());
+        Base::set_periodic_v(homogeneous.get_periodic_v());
         validate_initialization();
     }
 
@@ -355,6 +357,15 @@ protected:
         const auto& ctrl_pts = m_homogeneous.get_control_grid();
         if (ctrl_pts.rows() != Base::m_control_grid.rows() || ctrl_pts.rows() != m_weights.rows()) {
             throw invalid_setting_error("Rational Bezier patch is not initialized.");
+        }
+        if (Base::get_degree_u() < 0 || Base::get_degree_v() < 0) {
+            throw invalid_setting_error("Rational Bezier patch degrees are not initialized.");
+        }
+        if (m_homogeneous.get_periodic_u() != Base::get_periodic_u()) {
+            throw invalid_setting_error("Rational Bezier patch is inconsistent in u periodicity.");
+        }
+        if (m_homogeneous.get_periodic_v() != Base::get_periodic_v()) {
+            throw invalid_setting_error("Rational Bezier patch is inconsistent in v periodicity.");
         }
     }
 

--- a/tests/test_BSpline.cpp
+++ b/tests/test_BSpline.cpp
@@ -751,5 +751,9 @@ TEST_CASE("BSpline", "[nonrational][bspline]")
         Scalar t3 =
             curve.approximate_inverse_evaluate(q, t_min - period / 5, t_min + period / 5, 10);
         REQUIRE((curve.evaluate(t3) - p).norm() == Approx(s).margin(2e-2));
+
+        auto curve2 = curve.elevate_degree();
+        REQUIRE(curve2.get_periodic() == curve.get_periodic());
+        assert_same(curve, curve2, 10);
     }
 }

--- a/tests/test_Bezier.cpp
+++ b/tests/test_Bezier.cpp
@@ -587,5 +587,9 @@ TEST_CASE("Bezier", "[nonrational][bezier]") {
         REQUIRE(curve.evaluate(t2).norm() == Approx(0.0).margin(1e-3));
         Scalar t3 = curve.approximate_inverse_evaluate(q, -2.1, -1.9, 10);
         REQUIRE(curve.evaluate(t3).norm() == Approx(0.0).margin(1e-3));
+
+        auto curve2 = curve.elevate_degree();
+        REQUIRE(curve2.get_periodic());
+        assert_same(curve, curve2, 10);
     }
 }

--- a/tests/test_NURBS.cpp
+++ b/tests/test_NURBS.cpp
@@ -518,6 +518,7 @@ TEST_CASE("NURBS", "[rational][nurbs][bspline]") {
         REQUIRE(curve.is_closed(1, 1e-6));
 
         curve.set_periodic(true);
+        curve.initialize();
 
         Eigen::Matrix<Scalar, 1, 2> q(0.0, -1.0);
         Scalar t0 = curve.approximate_inverse_evaluate(q, 0, 1);
@@ -528,5 +529,9 @@ TEST_CASE("NURBS", "[rational][nurbs][bspline]") {
         REQUIRE(curve.evaluate(t2).norm() == Approx(0.0));
         Scalar t3 = curve.approximate_inverse_evaluate(q, 2.25, 2.75);
         REQUIRE(curve.evaluate(t3).norm() > 0.1);
+
+        auto curve2 = curve.elevate_degree();
+        REQUIRE(curve2.get_periodic());
+        assert_same(curve, curve2, 10);
     }
 }

--- a/tests/test_RationalBezier.cpp
+++ b/tests/test_RationalBezier.cpp
@@ -435,6 +435,8 @@ TEST_CASE("RationalBezier", "[rational][bezier]") {
         REQUIRE(!curve.is_closed(2));
 
         curve.set_periodic(true);
+        curve.initialize();
+
         Eigen::Matrix<Scalar, 1, 2> q(-1, -1);
         Scalar t0 = curve.approximate_inverse_evaluate(q, 0, 1);
         REQUIRE(curve.evaluate(t0).norm() == Approx(0.0));
@@ -444,5 +446,9 @@ TEST_CASE("RationalBezier", "[rational][bezier]") {
         REQUIRE(curve.evaluate(t2).norm() == Approx(0.0).margin(1e-3));
         Scalar t3 = curve.approximate_inverse_evaluate(q, 2.25, 2.75);
         REQUIRE(curve.evaluate(t3).norm() > 0.1);
+
+        auto curve2 = curve.elevate_degree();
+        REQUIRE(curve2.get_periodic());
+        assert_same(curve, curve2, 10);
     }
 }


### PR DESCRIPTION
Summary:
* Add more unit tests for periodic patches.
* Remove copy constructors and assignment operators.  They seems to be unnecessary.
* Roll back to use naive bisection method to narrow down search range.