### PR TITLE
Inverse evaluation bug fix

### DIFF
--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -41,9 +41,7 @@ public:
         Base::set_degree_v(_degree_v);
     }
 
-    std::unique_ptr<Base> clone() const override {
-        return std::make_unique<ThisType>(*this);
-    }
+    std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
 
 public:
     Point evaluate(Scalar u, Scalar v) const override
@@ -511,13 +509,29 @@ public:
             return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
         }
 
+        // When there are too few control points, this approach does not
+        // effectively shrink the search region.  Roll back to sampling.
+        if (num_control_points_u() <= 3 || num_control_points_v() <= 3) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
+        }
+
         // 1. find closest control point
         auto closest_control_pt_index = Base::find_closest_control_point(p);
         int i_min = closest_control_pt_index.first;
         int j_min = closest_control_pt_index.second;
 
+        auto clamp_2d = [](auto& uv, Scalar min_u, Scalar max_u, Scalar min_v, Scalar max_v) {
+            uv[0] = std::max(uv[0], min_u);
+            uv[0] = std::min(uv[0], max_u);
+            uv[1] = std::max(uv[1], min_v);
+            uv[1] = std::min(uv[1], max_v);
+        };
+
+
         if (level <= 0) {
-            return get_control_point_preimage(i_min, j_min);
+            auto uv = get_control_point_preimage(i_min, j_min);
+            clamp_2d(uv, min_u, max_u, min_v, max_v);
+            return uv;
 
         } else {
             // 2. Control points c_{i+/-1,j+/-1} bound the domain containing our
@@ -529,6 +543,8 @@ public:
             UVPoint uv_max =
                 get_control_point_preimage(i_min < num_control_points_u() - 1 ? i_min + 1 : i_min,
                     j_min < num_control_points_v() - 1 ? j_min + 1 : j_min);
+            clamp_2d(uv_min, min_u, max_u, min_v, max_v);
+            clamp_2d(uv_max, min_u, max_u, min_v, max_v);
 
             // 3. split a subcurve to find closest ctrl points on subdomain
             ThisType patch = subpatch(uv_min(0), uv_max(0), uv_min(1), uv_max(1));

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -550,8 +550,7 @@ public:
             ThisType patch = subpatch(uv_min(0), uv_max(0), uv_min(1), uv_max(1));
 
             // 4. repeat recursively
-            UVPoint uv = patch.approximate_inverse_evaluate(
-                p, num_samples, uv_min(0), uv_max(0), uv_min(1), uv_max(1), level - 1);
+            UVPoint uv = patch.approximate_inverse_evaluate(p, num_samples, 0, 1, 0, 1, level - 1);
 
             // 5. remap solution up through affine subdomain transformations
             uv(0) = (uv_max(0) - uv_min(0)) * uv(0) + uv_min(0);

--- a/include/nanospline/PatchBase.h
+++ b/include/nanospline/PatchBase.h
@@ -172,9 +172,9 @@ protected:
         UVPoint uv(min_u, min_v);
         Scalar min_dist = std::numeric_limits<Scalar>::max();
         for (int i = 0; i <= num_samples; i++) {
-            const Scalar u = i * (max_u - min_u) / num_samples + min_u;
+            const Scalar u = (i == num_samples) ? max_u : i * (max_u - min_u) / num_samples + min_u;
             for (int j = 0; j <= num_samples; j++) {
-                const Scalar v = j * (max_v - min_v) / num_samples + min_v;
+                const Scalar v = (j == num_samples) ? max_v : j * (max_v - min_v) / num_samples + min_v;
                 const Point q = this->evaluate(u, v);
                 const auto dist = (p - q).squaredNorm();
                 if (dist < min_dist) {

--- a/include/nanospline/PatchBase.h
+++ b/include/nanospline/PatchBase.h
@@ -128,7 +128,10 @@ public:
         constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 100;
         const int num_samples = std::max(num_control_points_u(), num_control_points_v()) + 1;
         UVPoint uv = approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v, 10);
-        return newton_raphson(p, uv, 20, TOL, min_u, max_u, min_v, max_v);
+        uv = newton_raphson(p, uv, 20, TOL, min_u, max_u, min_v, max_v);
+        assert(uv[0] >= min_u && uv[0] <= max_u);
+        assert(uv[1] >= min_v && uv[1] <= max_v);
+        return uv;
     }
 
 public:

--- a/include/nanospline/RationalBezierPatch.h
+++ b/include/nanospline/RationalBezierPatch.h
@@ -354,8 +354,7 @@ public:
             ThisType patch = subpatch(uv_min(0), uv_max(0), uv_min(1), uv_max(1));
 
             // repeat recursively
-            UVPoint uv = patch.approximate_inverse_evaluate(
-                p, num_samples, uv_min(0), uv_max(0), uv_min(1), uv_max(1), level - 1);
+            UVPoint uv = patch.approximate_inverse_evaluate(p, num_samples, 0, 1, 0, 1, level - 1);
 
             // remap solution up through affine subdomain transformations
             uv(0) = (uv_max(0) - uv_min(0)) * uv(0) + uv_min(0);

--- a/include/nanospline/RationalBezierPatch.h
+++ b/include/nanospline/RationalBezierPatch.h
@@ -31,9 +31,7 @@ public:
         Base::set_degree_v(_degree_v);
     }
 
-    std::unique_ptr<Base> clone() const override {
-        return std::make_unique<ThisType>(*this);
-    }
+    std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
 
 public:
     int num_control_points_u() const override { return m_homogeneous.num_control_points_u(); }
@@ -312,6 +310,12 @@ public:
             return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
         }
 
+        // When there are too few control points, this approach does not
+        // effectively shrink the search region.  Roll back to sampling.
+        if (num_control_points_u() <= 3 || num_control_points_v() <= 3) {
+            return Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v);
+        }
+
         // 1. find closest control point
         // (works for points with 0 weight: Base::m_control_grid is scaled by
         // corresponding weights when initialized, so c_i/w_i = inf as w_i-> 0
@@ -320,8 +324,18 @@ public:
         int i_min = closest_control_pt_index.first;
         int j_min = closest_control_pt_index.second;
 
+        auto clamp_2d = [](auto& uv, Scalar min_u, Scalar max_u, Scalar min_v, Scalar max_v) {
+            uv[0] = std::max(uv[0], min_u);
+            uv[0] = std::min(uv[0], max_u);
+            uv[1] = std::max(uv[1], min_v);
+            uv[1] = std::min(uv[1], max_v);
+        };
+
+
         if (level <= 0) {
-            return get_control_point_preimage(i_min, j_min);
+            auto uv = get_control_point_preimage(i_min, j_min);
+            clamp_2d(uv, min_u, max_u, min_v, max_v);
+            return uv;
 
         } else {
             // 2. Control points c_{i+/-1,j+/-1} bound the domain containing our
@@ -333,6 +347,8 @@ public:
             UVPoint uv_max =
                 get_control_point_preimage(i_min < num_control_points_u() - 1 ? i_min + 1 : i_min,
                     j_min < num_control_points_v() - 1 ? j_min + 1 : j_min);
+            clamp_2d(uv_min, min_u, max_u, min_v, max_v);
+            clamp_2d(uv_max, min_u, max_u, min_v, max_v);
 
             // 3. split a subcurve to find closest ctrl points on subdomain
             ThisType patch = subpatch(uv_min(0), uv_max(0), uv_min(1), uv_max(1));


### PR DESCRIPTION
Summary:
* Fix the bug that approximate inverse evaluation does not respect search range.
* Another bug on cases where approximate inverse evaluation failed to reduce the search range.
* Yet another bug fix for Bezier and RationalBezier patch to correctly specify search range in recursive calls.
* Add unit tests.