### PR TITLE
Primitive support

### DIFF
--- a/include/nanospline/BSpline.h
+++ b/include/nanospline/BSpline.h
@@ -49,6 +49,8 @@ public:
         combine_Beziers(beziers, parameter_bounds);
     }
 
+    CurveEnum get_curve_type() const override { return CurveEnum::BSPLINE; }
+
     std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override {
         return std::make_unique<ThisType>(*this);
     }

--- a/include/nanospline/BSplinePatch.h
+++ b/include/nanospline/BSplinePatch.h
@@ -3,6 +3,7 @@
 #include <nanospline/BSpline.h>
 #include <nanospline/Exceptions.h>
 #include <nanospline/PatchBase.h>
+#include <nanospline/split.h>
 
 using std::vector;
 
@@ -56,6 +57,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::BSPLINE; }
 
 public:
     Point evaluate(Scalar u, Scalar v) const override

--- a/include/nanospline/Bezier.h
+++ b/include/nanospline/Bezier.h
@@ -33,6 +33,8 @@ public:
 public:
     Bezier() = default;
 
+    CurveEnum get_curve_type() const override { return CurveEnum::BEZIER; }
+
     std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override
     {
         return std::make_unique<ThisType>(*this);
@@ -432,6 +434,8 @@ public:
     using ControlPoints = typename Base::ControlPoints;
 
 public:
+    CurveEnum get_curve_type() const override { return CurveEnum::BEZIER; }
+
     std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override
     {
         return std::make_unique<Bezier<_Scalar, _dim, 0, false>>(*this);
@@ -488,6 +492,8 @@ public:
     using ControlPoints = typename Base::ControlPoints;
 
 public:
+    CurveEnum get_curve_type() const override { return CurveEnum::BEZIER; }
+
     std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override
     {
         return std::make_unique<Bezier<_Scalar, _dim, 1, false>>(*this);
@@ -582,6 +588,8 @@ public:
     using ControlPoints = typename Base::ControlPoints;
 
 public:
+    CurveEnum get_curve_type() const override { return CurveEnum::BEZIER; }
+
     std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override
     {
         return std::make_unique<Bezier<_Scalar, _dim, 2, false>>(*this);
@@ -772,6 +780,8 @@ public:
     using ControlPoints = typename Base::ControlPoints;
 
 public:
+    CurveEnum get_curve_type() const override { return CurveEnum::BEZIER; }
+
     std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override
     {
         return std::make_unique<Bezier<_Scalar, _dim, 3, false>>(*this);

--- a/include/nanospline/BezierPatch.h
+++ b/include/nanospline/BezierPatch.h
@@ -2,6 +2,7 @@
 
 #include <nanospline/Bezier.h>
 #include <nanospline/PatchBase.h>
+#include <nanospline/split.h>
 
 namespace nanospline {
 
@@ -42,6 +43,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::BEZIER; }
 
 public:
     Point evaluate(Scalar u, Scalar v) const override

--- a/include/nanospline/Circle.h
+++ b/include/nanospline/Circle.h
@@ -23,7 +23,6 @@ public:
         m_frame.setZero();
         m_frame(0, 0) = 1;
         m_frame(1, 1) = 1;
-        update_periodicity();
     }
 
     CurveEnum get_curve_type() const override { return CurveEnum::CIRCLE; }
@@ -45,6 +44,7 @@ public:
         assert(m_radius > 0);
         assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
         assert(m_upper >= m_lower);
+        update_periodicity(TOL);
     }
 
 public:
@@ -61,12 +61,10 @@ public:
     void set_domain_lower_bound(Scalar t)
     {
         m_lower = t;
-        update_periodicity();
     }
     void set_domain_upper_bound(Scalar t)
     {
         m_upper = t;
-        update_periodicity();
     }
 
 public:
@@ -183,9 +181,9 @@ public:
     }
 
 private:
-    void update_periodicity()
+    void update_periodicity(Scalar TOL)
     {
-        if (std::abs(fmod(m_upper - m_lower, 2 * M_PI)) < 1e-6) {
+        if (std::abs(fmod(m_upper - m_lower, 2 * M_PI)) < TOL) {
             Base::set_periodic(true);
         } else {
             Base::set_periodic(false);

--- a/include/nanospline/Circle.h
+++ b/include/nanospline/Circle.h
@@ -45,11 +45,14 @@ public:
     const Frame get_frame() const { return m_frame; }
     void set_frame(const Frame& f) { m_frame = f; }
 
+    void set_domain_lower_bound(Scalar t) { m_lower = t; }
+    void set_domain_upper_bound(Scalar t) { m_upper = t; }
+
 public:
     int get_degree() const override { return -1; }
-    bool in_domain(Scalar t) const override { return true; }
-    Scalar get_domain_lower_bound() const override { return 0; }
-    Scalar get_domain_upper_bound() const override { return 2 * M_PI; }
+    bool in_domain(Scalar t) const override { return t >= m_lower && t <= m_upper; }
+    Scalar get_domain_lower_bound() const override { return m_lower; }
+    Scalar get_domain_upper_bound() const override { return m_upper; }
 
 public:
     Point evaluate(Scalar t) const override
@@ -143,6 +146,8 @@ private:
     Point m_center = Point::Zero();
     Frame m_frame;
     Scalar m_radius = 0;
+    Scalar m_lower = 0;
+    Scalar m_upper = 2 * M_PI;
 };
 
 } // namespace nanospline

--- a/include/nanospline/Circle.h
+++ b/include/nanospline/Circle.h
@@ -88,7 +88,7 @@ public:
         const Point& p, const Scalar lower, const Scalar upper, const int level = 3) const override
     {
         (void)level; // Level is not needed here.
-        assert(lower < upper);
+        assert(lower <= upper);
 
         const Scalar x = m_frame.row(0).dot(p - m_center) / m_frame.row(0).norm();
         const Scalar y = m_frame.row(1).dot(p - m_center) / m_frame.row(1).norm();
@@ -147,15 +147,27 @@ public:
         return {};
     }
 
-    std::vector<Scalar> reduce_turning_angle(const Scalar, const Scalar) const override
+    std::vector<Scalar> reduce_turning_angle(const Scalar lower, const Scalar upper) const override
     {
-        // TODO.
-        throw not_implemented_error("Turning angle of a circle cannot be reduced.");
+        if (_dim != 2) {
+            throw std::runtime_error("Turning angle reduction is for 2D curves only");
+        }
+        assert(lower <= upper);
+        return {(lower + upper) / 2};
     }
 
     std::vector<Scalar> compute_singularities(const Scalar, const Scalar) const override
     {
         return {};
+    }
+
+    Scalar get_turning_angle(Scalar t0, Scalar t1) const override
+    {
+        if (_dim != 2) {
+            throw std::runtime_error("Turning angle reduction is for 2D curves only");
+        }
+        assert(t0 <= t1);
+        return t1 - t0;
     }
 
 private:

--- a/include/nanospline/Circle.h
+++ b/include/nanospline/Circle.h
@@ -23,10 +23,11 @@ public:
         m_frame.setZero();
         m_frame(0, 0) = 1;
         m_frame(1, 1) = 1;
-        Base::set_periodic(true);
+        update_periodicity();
     }
 
-    std::unique_ptr<Base> clone() const override {
+    std::unique_ptr<Base> clone() const override
+    {
         auto ptr = std::make_unique<Circle<_Scalar, _dim>>();
         ptr->set_radius(m_radius);
         ptr->set_center(m_center);
@@ -45,8 +46,16 @@ public:
     const Frame get_frame() const { return m_frame; }
     void set_frame(const Frame& f) { m_frame = f; }
 
-    void set_domain_lower_bound(Scalar t) { m_lower = t; }
-    void set_domain_upper_bound(Scalar t) { m_upper = t; }
+    void set_domain_lower_bound(Scalar t)
+    {
+        m_lower = t;
+        update_periodicity();
+    }
+    void set_domain_upper_bound(Scalar t)
+    {
+        m_upper = t;
+        update_periodicity();
+    }
 
 public:
     int get_degree() const override { return -1; }
@@ -79,7 +88,7 @@ public:
     }
 
     Scalar approximate_inverse_evaluate(
-        const Point& p, const Scalar lower, const Scalar upper, const int level=3) const override
+        const Point& p, const Scalar lower, const Scalar upper, const int level = 3) const override
     {
         (void)level; // Level is not needed here.
 
@@ -140,6 +149,16 @@ public:
     std::vector<Scalar> compute_singularities(const Scalar, const Scalar) const override
     {
         return {};
+    }
+
+private:
+    void update_periodicity()
+    {
+        if (std::abs(fmod(m_upper - m_lower, 2 * M_PI)) < 1e-6) {
+            Base::set_periodic(true);
+        } else {
+            Base::set_periodic(false);
+        }
     }
 
 private:

--- a/include/nanospline/Circle.h
+++ b/include/nanospline/Circle.h
@@ -34,7 +34,17 @@ public:
         ptr->set_radius(m_radius);
         ptr->set_center(m_center);
         ptr->set_frame(m_frame);
+        ptr->set_domain_lower_bound(m_lower);
+        ptr->set_domain_upper_bound(m_upper);
         return ptr;
+    }
+
+    void initialize() override
+    {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        assert(m_radius > 0);
+        assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
+        assert(m_upper >= m_lower);
     }
 
 public:

--- a/include/nanospline/Circle.h
+++ b/include/nanospline/Circle.h
@@ -26,6 +26,8 @@ public:
         update_periodicity();
     }
 
+    CurveEnum get_curve_type() const override { return CurveEnum::CIRCLE; }
+
     std::unique_ptr<Base> clone() const override
     {
         auto ptr = std::make_unique<Circle<_Scalar, _dim>>();

--- a/include/nanospline/Circle.h
+++ b/include/nanospline/Circle.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <nanospline/CurveBase.h>
+#include <nanospline/Exceptions.h>
+
+namespace nanospline {
+
+template <typename _Scalar, int _dim>
+class Circle final : public CurveBase<_Scalar, _dim>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    static_assert(_dim > 1, "Dimension must be greater than 1.");
+    using Base = CurveBase<_Scalar, _dim>;
+    using typename Base::Point;
+    using typename Base::Scalar;
+    using Frame = Eigen::Matrix<_Scalar, 2, _dim>;
+
+public:
+    Circle()
+        : Base()
+    {
+        m_frame.setZero();
+        m_frame(0, 0) = 1;
+        m_frame(1, 1) = 1;
+        Base::set_periodic(true);
+    }
+
+    std::unique_ptr<Base> clone() const override {
+        auto ptr = std::make_unique<Circle<_Scalar, _dim>>();
+        ptr->set_radius(m_radius);
+        ptr->set_center(m_center);
+        ptr->set_frame(m_frame);
+        return ptr;
+    }
+
+public:
+    Scalar get_radius() const { return m_radius; }
+    void set_radius(Scalar r) { m_radius = r; }
+
+    const Point& get_center() const { return m_center; }
+    void set_center(const Point& c) { m_center = c; }
+
+    // Circle is embedded in the plane spanned by the first 2 axes of the frame.
+    const Frame get_frame() const { return m_frame; }
+    void set_frame(const Frame& f) { m_frame = f; }
+
+public:
+    int get_degree() const override { return -1; }
+    bool in_domain(Scalar t) const override { return true; }
+    Scalar get_domain_lower_bound() const override { return 0; }
+    Scalar get_domain_upper_bound() const override { return 2 * M_PI; }
+
+public:
+    Point evaluate(Scalar t) const override
+    {
+        return m_center + m_radius * (m_frame.row(0) * std::cos(t) + m_frame.row(1) * std::sin(t));
+    }
+
+    Scalar inverse_evaluate(const Point& p) const override
+    {
+        const Scalar x = m_frame.row(0).dot(p - m_center) / m_frame.row(0).norm();
+        const Scalar y = m_frame.row(1).dot(p - m_center) / m_frame.row(1).norm();
+        auto t = std::atan2(y, x);
+        return Base::unwrap_parameter(t);
+    }
+
+    Point evaluate_derivative(Scalar t) const override
+    {
+        return m_radius * (-m_frame.row(0) * std::sin(t) + m_frame.row(1) * std::cos(t));
+    }
+
+    Point evaluate_2nd_derivative(Scalar t) const override
+    {
+        return m_radius * (-m_frame.row(0) * std::cos(t) - m_frame.row(1) * std::sin(t));
+    }
+
+    Scalar approximate_inverse_evaluate(
+        const Point& p, const Scalar lower, const Scalar upper, const int level=3) const override
+    {
+        (void)level; // Level is not needed here.
+
+        Scalar t = inverse_evaluate(p);
+        if (t >= lower && t <= upper) return t;
+
+        Scalar dist_lower = (evaluate(lower) - p).squaredNorm();
+        Scalar dist_upper = (evaluate(upper) - p).squaredNorm();
+        if (dist_lower < dist_upper) {
+            return lower;
+        } else {
+            return upper;
+        }
+    }
+
+public:
+    int get_num_control_points() const override { return 0; }
+    Point get_control_point(int) const override
+    {
+        throw not_implemented_error("Circle does not support control points.");
+    }
+    void set_control_point(int, const Point&) override
+    {
+        throw not_implemented_error("Circle does not support control points.");
+    }
+
+    int get_num_weights() const override { return 0; }
+    Scalar get_weight(int) const override
+    {
+        throw not_implemented_error("Circle does not support weights.");
+    }
+    void set_weight(int, Scalar) override
+    {
+        throw not_implemented_error("Circle does not support weights.");
+    }
+
+    int get_num_knots() const override { return 0; }
+    Scalar get_knot(int) const override
+    {
+        throw not_implemented_error("Circle does not support knots.");
+    }
+    void set_knot(int, Scalar) override
+    {
+        throw not_implemented_error("Circle does not support knots.");
+    }
+
+public:
+    std::vector<Scalar> compute_inflections(const Scalar, const Scalar) const override
+    {
+        return {};
+    }
+
+    std::vector<Scalar> reduce_turning_angle(const Scalar, const Scalar) const override
+    {
+        throw not_implemented_error("Turning angle of a circle cannot be reduced.");
+    }
+
+    std::vector<Scalar> compute_singularities(const Scalar, const Scalar) const override
+    {
+        return {};
+    }
+
+private:
+    Point m_center = Point::Zero();
+    Frame m_frame;
+    Scalar m_radius = 0;
+};
+
+} // namespace nanospline

--- a/include/nanospline/Cone.h
+++ b/include/nanospline/Cone.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <nanospline/PatchBase.h>
+
+namespace nanospline {
+
+template <typename _Scalar, int _dim>
+class Cone final : public PatchBase<_Scalar, _dim>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    static_assert(_dim > 2, "Dimension must be larger than 2.");
+
+    using Base = PatchBase<_Scalar, _dim>;
+    using ThisType = Cone<_Scalar, _dim>;
+    using Scalar = typename Base::Scalar;
+    using Point = typename Base::Point;
+    using UVPoint = typename Base::UVPoint;
+    using Frame = Eigen::Matrix<Scalar, 3, _dim>;
+
+public:
+    Cone()
+    {
+        m_location.setZero();
+        m_frame.setZero();
+        m_frame(0, 0) = 1;
+        m_frame(1, 1) = 1;
+        m_frame(2, 2) = 1;
+        Base::set_degree_u(2);
+        Base::set_degree_v(1);
+    }
+
+    std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+
+    const Point& get_location() const { return m_location; }
+    void set_location(const Point& p) { m_location = p; }
+
+    const Frame& get_frame() const { return m_frame; }
+    void set_frame(const Frame& f) { m_frame = f; }
+
+    Scalar get_radius() const { return m_radius; }
+    void set_radius(Scalar r) { m_radius = r; }
+
+    Scalar get_angle() const { return m_angle; }
+    void set_angle(Scalar a) { m_angle = a; }
+
+public:
+    Point evaluate(Scalar u, Scalar v) const override
+    {
+        return m_location +
+               (m_radius + v * std::sin(m_angle)) *
+                   (m_frame.row(0) * std::cos(u) + m_frame.row(1) * std::sin(u)) +
+               m_frame.row(2) * v * std::cos(m_angle);
+    }
+
+    Point evaluate_derivative_u(Scalar u, Scalar v) const override
+    {
+        return (m_radius + v * std::sin(m_angle)) *
+               (-m_frame.row(0) * std::sin(u) + m_frame.row(1) * std::cos(u));
+    }
+
+    Point evaluate_derivative_v(Scalar u, Scalar v) const override
+    {
+        return std::sin(m_angle) * (m_frame.row(0) * std::cos(u) + m_frame.row(1) * std::sin(u)) +
+               m_frame.row(2) * std::cos(m_angle);
+    }
+
+    Point evaluate_2nd_derivative_uu(Scalar u, Scalar v) const override
+    {
+        return (m_radius + v * std::sin(m_angle)) *
+               (-m_frame.row(0) * std::cos(u) - m_frame.row(1) * std::sin(u));
+    }
+
+    Point evaluate_2nd_derivative_vv(Scalar u, Scalar v) const override {
+        return Point::Zero();
+    }
+
+    Point evaluate_2nd_derivative_uv(Scalar u, Scalar v) const override {
+        return std::sin(m_angle) *
+               (-m_frame.row(0) * std::sin(u) + m_frame.row(1) * std::cos(u));
+    }
+
+    UVPoint inverse_evaluate(const Point& p,
+        const Scalar min_u,
+        const Scalar max_u,
+        const Scalar min_v,
+        const Scalar max_v) const override
+    {
+        UVPoint uv;
+        const Scalar x = (p - m_location).dot(m_frame.row(0));
+        const Scalar y = (p - m_location).dot(m_frame.row(1));
+        uv[0] = std::atan2(y, x);
+
+        const Point v = std::cos(uv[0]) * m_frame.row(0) + std::sin(uv[0]) * m_frame.row(1);
+        const Point q = m_radius * v;
+        const Point d = std::sin(m_angle) * v + std::cos(m_angle) * m_frame.row(2);
+        uv[1] = (p - q).dot(d) / d.squaredNorm();
+        assert(uv.array().isFinite().all());
+
+        uv[1] = std::max(min_v, std::min(uv[1], max_v));
+        if (uv[0] < min_u) {
+            int n = static_cast<int>(std::ceil((min_u - uv[0]) / (2 * M_PI)));
+            uv[0] += n * 2 * M_PI;
+        }
+        if (uv[0] > max_u) {
+            const Scalar du_min = 2 * M_PI - (uv[0] - min_u);
+            const Scalar du_max = uv[0] - max_u;
+            if (du_min < du_max) {
+                uv[0] = min_u;
+            } else {
+                uv[0] = max_u;
+            }
+        }
+
+        assert(uv.array().isFinite().all());
+        return uv;
+    }
+
+    void initialize() override
+    {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        assert(std::abs(m_frame.row(0).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(1).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(2).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
+        assert(std::abs(m_frame.row(1).dot(m_frame.row(2))) < TOL);
+        assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
+        assert(m_u_upper > m_u_lower);
+        assert(m_v_upper > m_v_lower);
+    }
+
+    Scalar get_u_lower_bound() const override { return m_u_lower; }
+    Scalar get_u_upper_bound() const override { return m_u_upper; }
+    Scalar get_v_lower_bound() const override { return m_v_lower; }
+    Scalar get_v_upper_bound() const override { return m_v_upper; }
+
+    void set_u_lower_bound(Scalar t) { m_u_lower = t; }
+    void set_u_upper_bound(Scalar t) { m_u_upper = t; }
+    void set_v_lower_bound(Scalar t) { m_v_lower = t; }
+    void set_v_upper_bound(Scalar t) { m_v_upper = t; }
+
+public:
+    virtual int get_num_weights_u() const override { return 0; }
+    virtual int get_num_weights_v() const override { return 0; }
+    virtual Scalar get_weight(int i, int j) const override
+    {
+        throw not_implemented_error("Cone patch does not support weight");
+    }
+    virtual void set_weight(int i, int j, Scalar val) override
+    {
+        throw not_implemented_error("Cone patch does not support weight");
+    }
+
+    virtual int get_num_knots_u() const override { return 0; }
+    virtual Scalar get_knot_u(int i) const override
+    {
+        throw not_implemented_error("Cone patch does not support knots");
+    }
+    virtual void set_knot_u(int i, Scalar val) override
+    {
+        throw not_implemented_error("Cone patch does not support knots");
+    }
+
+    virtual int get_num_knots_v() const override { return 0; }
+    virtual Scalar get_knot_v(int i) const override
+    {
+        throw not_implemented_error("Cone patch does not support knots");
+    }
+    virtual void set_knot_v(int i, Scalar val) override
+    {
+        throw not_implemented_error("Cone patch does not support knots");
+    }
+
+public:
+    int num_control_points_u() const override { return 0; }
+
+    int num_control_points_v() const override { return 0; }
+
+    UVPoint get_control_point_preimage(int i, int j) const override
+    {
+        throw not_implemented_error("Cone does not need control points.");
+    }
+
+private:
+    Point m_location;
+    Frame m_frame;
+    Scalar m_radius = 1;
+    Scalar m_angle = M_PI / 2;
+    Scalar m_u_lower = 0;
+    Scalar m_u_upper = 2 * M_PI;
+    Scalar m_v_lower = 0;
+    Scalar m_v_upper = 1;
+};
+
+} // namespace nanospline

--- a/include/nanospline/Cone.h
+++ b/include/nanospline/Cone.h
@@ -128,6 +128,8 @@ public:
         assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
         assert(m_u_upper > m_u_lower);
         assert(m_v_upper > m_v_lower);
+        Base::set_periodic_u((fmod(m_u_upper - m_u_lower, 2 * M_PI) < TOL));
+        Base::set_periodic_v(false);
     }
 
     Scalar get_u_lower_bound() const override { return m_u_lower; }

--- a/include/nanospline/Cone.h
+++ b/include/nanospline/Cone.h
@@ -31,6 +31,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::CONE; }
 
     const Point& get_location() const { return m_location; }
     void set_location(const Point& p) { m_location = p; }

--- a/include/nanospline/CurveBase.h
+++ b/include/nanospline/CurveBase.h
@@ -1,14 +1,16 @@
 #pragma once
 
+#include <nanospline/Exceptions.h>
+#include <nanospline/enums.h>
+
+#include <Eigen/Core>
+
+#include <cassert>
 #include <cmath>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <vector>
 
-#include <nanospline/Exceptions.h>
-#include <nanospline/enums.h>
-#include <Eigen/Core>
 namespace nanospline {
 
 template <typename _Scalar, int _dim>
@@ -25,7 +27,7 @@ public:
 
     virtual void initialize() {}
 
-    virtual CurveEnum get_curve_type() const =0;
+    virtual CurveEnum get_curve_type() const = 0;
 
     constexpr int get_dim() const { return _dim; }
     virtual int get_degree() const = 0;

--- a/include/nanospline/CurveBase.h
+++ b/include/nanospline/CurveBase.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <nanospline/Exceptions.h>
+#include <nanospline/enums.h>
 #include <Eigen/Core>
 namespace nanospline {
 
@@ -23,6 +24,8 @@ public:
     virtual std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const = 0;
 
     virtual void initialize() {}
+
+    virtual CurveEnum get_curve_type() const =0;
 
     constexpr int get_dim() const { return _dim; }
     virtual int get_degree() const = 0;

--- a/include/nanospline/Cylinder.h
+++ b/include/nanospline/Cylinder.h
@@ -106,6 +106,9 @@ public:
         assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
         assert(m_u_upper > m_u_lower);
         assert(m_v_upper > m_v_lower);
+
+        Base::set_periodic_u((fmod(m_u_upper - m_u_lower, 2 * M_PI) < TOL));
+        Base::set_periodic_v(false);
     }
 
     Scalar get_u_lower_bound() const override { return m_u_lower; }

--- a/include/nanospline/Cylinder.h
+++ b/include/nanospline/Cylinder.h
@@ -31,6 +31,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::CYLINDER; }
 
     const Point& get_location() const { return m_location; }
     void set_location(const Point& p) { m_location = p; }

--- a/include/nanospline/Cylinder.h
+++ b/include/nanospline/Cylinder.h
@@ -5,27 +5,28 @@
 namespace nanospline {
 
 template <typename _Scalar, int _dim>
-class Plane final : public PatchBase<_Scalar, _dim>
+class Cylinder final : public PatchBase<_Scalar, _dim>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    static_assert(_dim > 1, "Dimension must be larger than 1.");
+    static_assert(_dim > 2, "Dimension must be larger than 2.");
 
     using Base = PatchBase<_Scalar, _dim>;
-    using ThisType = Plane<_Scalar, _dim>;
+    using ThisType = Cylinder<_Scalar, _dim>;
     using Scalar = typename Base::Scalar;
     using Point = typename Base::Point;
     using UVPoint = typename Base::UVPoint;
-    using Frame = Eigen::Matrix<Scalar, 2, _dim>;
+    using Frame = Eigen::Matrix<Scalar, 3, _dim>;
 
 public:
-    Plane()
+    Cylinder()
     {
         m_location.setZero();
         m_frame.setZero();
         m_frame(0, 0) = 1;
         m_frame(1, 1) = 1;
-        Base::set_degree_u(1);
+        m_frame(2, 2) = 1;
+        Base::set_degree_u(2);
         Base::set_degree_v(1);
     }
 
@@ -37,17 +38,26 @@ public:
     const Frame& get_frame() const { return m_frame; }
     void set_frame(const Frame& f) { m_frame = f; }
 
+    Scalar get_radius() const { return m_radius; }
+    void set_radius(Scalar r) { m_radius = r; }
+
 public:
     Point evaluate(Scalar u, Scalar v) const override
     {
-        return m_location + m_frame.row(0) * u + m_frame.row(1) * v;
+        return m_location + m_frame.row(0) * std::cos(u) * m_radius +
+               m_frame.row(1) * std::sin(u) * m_radius + m_frame.row(2) * v;
     }
 
-    Point evaluate_derivative_u(Scalar u, Scalar v) const override { return m_frame.row(0); }
+    Point evaluate_derivative_u(Scalar u, Scalar v) const override
+    {
+        return -m_frame.row(0) * std::sin(u) * m_radius + m_frame.row(1) * std::cos(u) * m_radius;
+    }
 
-    Point evaluate_derivative_v(Scalar u, Scalar v) const override { return m_frame.row(1); }
+    Point evaluate_derivative_v(Scalar u, Scalar v) const override { return m_frame.row(2); }
 
-    Point evaluate_2nd_derivative_uu(Scalar u, Scalar v) const override { return Point::Zero(); }
+    Point evaluate_2nd_derivative_uu(Scalar u, Scalar v) const override {
+        return -m_frame.row(0) * std::cos(u) * m_radius - m_frame.row(1) * std::sin(u) * m_radius;
+    }
 
     Point evaluate_2nd_derivative_vv(Scalar u, Scalar v) const override { return Point::Zero(); }
 
@@ -60,12 +70,25 @@ public:
         const Scalar max_v) const override
     {
         UVPoint uv;
+        const Scalar x = (p - m_location).dot(m_frame.row(0));
+        const Scalar y = (p - m_location).dot(m_frame.row(1));
+        const Scalar z = (p - m_location).dot(m_frame.row(2));
+        uv[0] = std::atan2(y, x);
+        uv[1] = z;
 
-        uv[0] = (p - m_location).dot(m_frame.row(0)) / m_frame.row(0).squaredNorm();
-        uv[1] = (p - m_location).dot(m_frame.row(1)) / m_frame.row(1).squaredNorm();
-
-        uv[0] = std::max(min_u, std::min(uv[0], max_u));
         uv[1] = std::max(min_v, std::min(uv[1], max_v));
+        while (uv[0] < min_u) {
+            uv[0] += 2 * M_PI;
+        }
+        if (uv[0] > max_u) {
+            const Scalar d0 = (evaluate(min_u, uv[1]) - p).norm();
+            const Scalar d1 = (evaluate(max_u, uv[1]) - p).norm();
+            if (d0 < d1) {
+                uv[0] = min_u;
+            } else {
+                uv[0] = max_u;
+            }
+        }
 
         return uv;
     }
@@ -73,8 +96,12 @@ public:
     void initialize() override
     {
         constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
-        assert(m_frame.row(0).squaredNorm() > TOL);
-        assert(m_frame.row(1).squaredNorm() > TOL);
+        assert(std::abs(m_frame.row(0).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(1).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(2).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
+        assert(std::abs(m_frame.row(1).dot(m_frame.row(2))) < TOL);
+        assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
         assert(m_u_upper > m_u_lower);
         assert(m_v_upper > m_v_lower);
     }
@@ -94,31 +121,31 @@ public:
     virtual int get_num_weights_v() const override { return 0; }
     virtual Scalar get_weight(int i, int j) const override
     {
-        throw not_implemented_error("Plane patch does not support weight");
+        throw not_implemented_error("Cylinder patch does not support weight");
     }
     virtual void set_weight(int i, int j, Scalar val) override
     {
-        throw not_implemented_error("Plane patch does not support weight");
+        throw not_implemented_error("Cylinder patch does not support weight");
     }
 
     virtual int get_num_knots_u() const override { return 0; }
     virtual Scalar get_knot_u(int i) const override
     {
-        throw not_implemented_error("Plane patch does not support knots");
+        throw not_implemented_error("Cylinder patch does not support knots");
     }
     virtual void set_knot_u(int i, Scalar val) override
     {
-        throw not_implemented_error("Plane patch does not support knots");
+        throw not_implemented_error("Cylinder patch does not support knots");
     }
 
     virtual int get_num_knots_v() const override { return 0; }
     virtual Scalar get_knot_v(int i) const override
     {
-        throw not_implemented_error("Plane patch does not support knots");
+        throw not_implemented_error("Cylinder patch does not support knots");
     }
     virtual void set_knot_v(int i, Scalar val) override
     {
-        throw not_implemented_error("Plane patch does not support knots");
+        throw not_implemented_error("Cylinder patch does not support knots");
     }
 
 public:
@@ -128,14 +155,15 @@ public:
 
     UVPoint get_control_point_preimage(int i, int j) const override
     {
-        throw not_implemented_error("Plane does not need control points.");
+        throw not_implemented_error("Cylinder does not need control points.");
     }
 
 private:
     Point m_location;
     Frame m_frame;
+    Scalar m_radius = 1;
     Scalar m_u_lower = 0;
-    Scalar m_u_upper = 1;
+    Scalar m_u_upper = 2 * M_PI;
     Scalar m_v_lower = 0;
     Scalar m_v_upper = 1;
 };

--- a/include/nanospline/Ellipse.h
+++ b/include/nanospline/Ellipse.h
@@ -95,7 +95,7 @@ public:
         const Point& p, const Scalar lower, const Scalar upper, const int level = 3) const override
     {
         (void)level; // Level is not needed here.
-        assert(lower < upper);
+        assert(lower <= upper);
         auto x = (p - m_center).dot(m_frame.row(0)) / m_frame.row(0).norm();
         auto y = (p - m_center).dot(m_frame.row(1)) / m_frame.row(1).norm();
         auto t = std::atan2(y * m_major_radius, x * m_minor_radius);

--- a/include/nanospline/Ellipse.h
+++ b/include/nanospline/Ellipse.h
@@ -23,7 +23,6 @@ public:
         m_frame.setZero();
         m_frame(0, 0) = 1;
         m_frame(1, 1) = 1;
-        update_periodicity();
     }
 
     CurveEnum get_curve_type() const override { return CurveEnum::ELLIPSE; }
@@ -48,6 +47,7 @@ public:
         assert(m_major_radius >= m_minor_radius);
         assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
         assert(m_upper >= m_lower);
+        update_periodicity(TOL);
     }
 
 public:
@@ -67,12 +67,10 @@ public:
     void set_domain_lower_bound(Scalar t)
     {
         m_lower = t;
-        update_periodicity();
     }
     void set_domain_upper_bound(Scalar t)
     {
         m_upper = t;
-        update_periodicity();
     }
 
 public:
@@ -234,9 +232,9 @@ public:
     }
 
 private:
-    void update_periodicity()
+    void update_periodicity(const Scalar tol)
     {
-        if (std::abs(fmod(m_upper - m_lower, 2 * M_PI)) < 1e-6) {
+        if (std::abs(fmod(m_upper - m_lower, 2 * M_PI)) < tol) {
             Base::set_periodic(true);
         } else {
             Base::set_periodic(false);

--- a/include/nanospline/Ellipse.h
+++ b/include/nanospline/Ellipse.h
@@ -35,7 +35,19 @@ public:
         ptr->set_minor_radius(m_minor_radius);
         ptr->set_center(m_center);
         ptr->set_frame(m_frame);
+        ptr->set_domain_lower_bound(m_lower);
+        ptr->set_domain_upper_bound(m_upper);
         return ptr;
+    }
+
+    void initialize() override
+    {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        assert(m_major_radius > 0);
+        assert(m_minor_radius > 0);
+        assert(m_major_radius >= m_minor_radius);
+        assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
+        assert(m_upper >= m_lower);
     }
 
 public:
@@ -98,14 +110,68 @@ public:
     {
         (void)level; // Level is not needed here.
         assert(lower <= upper);
-        auto x = (p - m_center).dot(m_frame.row(0)) / m_frame.row(0).norm();
-        auto y = (p - m_center).dot(m_frame.row(1)) / m_frame.row(1).norm();
-        auto t = std::atan2(y * m_major_radius, x * m_minor_radius);
 
+        Scalar t = M_PI / 4;
+        Scalar dt = std::numeric_limits<Scalar>::max();
+
+        const Point axis_1 = m_frame.row(0) / m_frame.row(0).norm();
+        const Point axis_2 = m_frame.row(1) / m_frame.row(1).norm();
+
+        // Limit query point p2 to the first quadrant.
+        Point p2 = p;
+        bool flip_x = (p - m_center).dot(axis_1) < 0;
+        bool flip_y = (p - m_center).dot(axis_2) < 0;
+        if (flip_x) {
+            p2 -= 2 * (p - m_center).dot(axis_1) * axis_1;
+        }
+        if (flip_y) {
+            p2 -= 2 * (p - m_center).dot(axis_2) * axis_2;
+        }
+
+        // Extract closest point on ellipse for p2.
+        // See https://wet-robots.ghost.io/simple-method-for-distance-to-ellipse/
+        const Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        int count = 0;
+        while (std::abs(dt) > TOL && count < 100) {
+            auto q = evaluate(t);
+            auto c = Base::evaluate_curvature(t);
+            auto sn = c.squaredNorm();
+            assert(sn > TOL);
+            auto r = 1 / sqrt(sn);
+            c = q + c / sn;
+
+            Scalar x = (q - m_center).dot(axis_1);
+            Scalar y = (q - m_center).dot(axis_2);
+            Scalar qx = (q - c).dot(axis_1);
+            Scalar qy = (q - c).dot(axis_2);
+            Scalar px = (p2 - c).dot(axis_1);
+            Scalar py = (p2 - c).dot(axis_2);
+
+            auto theta = std::atan2(qx * py - qy * px, qx * px + qy * py);
+            auto dc = r * theta;
+            dt = dc / sqrt(m_major_radius * m_major_radius + m_minor_radius * m_minor_radius -
+                           x * x - y * y);
+            t += dt;
+            if (t < 0) {
+                t = 0;
+            } else if (t > M_PI / 2) {
+                t = M_PI / 2;
+            }
+            count++;
+        }
+
+        // Find closest point for p using symmetry.
+        if (flip_x) {
+            t = M_PI - t;
+        }
+        if (flip_y) {
+            t = 2 * M_PI - t;
+        }
+
+        // Check for range and end points.
         while (t < lower) {
             t += 2 * M_PI;
         }
-
         if (t > upper) {
             auto d1 = (evaluate(lower) - p).squaredNorm();
             auto d2 = (evaluate(upper) - p).squaredNorm();
@@ -115,6 +181,7 @@ public:
                 t = upper;
             }
         }
+
         return t;
     }
 

--- a/include/nanospline/Ellipse.h
+++ b/include/nanospline/Ellipse.h
@@ -26,6 +26,8 @@ public:
         update_periodicity();
     }
 
+    CurveEnum get_curve_type() const override { return CurveEnum::ELLIPSE; }
+
     std::unique_ptr<Base> clone() const override
     {
         auto ptr = std::make_unique<Ellipse<_Scalar, _dim>>();

--- a/include/nanospline/ExtrusionPatch.h
+++ b/include/nanospline/ExtrusionPatch.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include <nanospline/PatchBase.h>
+
+namespace nanospline {
+
+template <typename _Scalar, int _dim>
+class ExtrusionPatch final : public PatchBase<_Scalar, _dim>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    static_assert(_dim == 3, "Surface of Extrusion is 3D only.");
+
+    using Base = PatchBase<_Scalar, _dim>;
+    using ThisType = ExtrusionPatch<_Scalar, _dim>;
+    using Scalar = typename Base::Scalar;
+    using Point = typename Base::Point;
+    using UVPoint = typename Base::UVPoint;
+    using Frame = Eigen::Matrix<Scalar, 3, _dim>;
+    using ProfileType = CurveBase<_Scalar, _dim>;
+
+public:
+    ExtrusionPatch()
+    {
+        m_location.setZero();
+        m_frame.setZero();
+        m_frame(0, 0) = 1;
+        m_frame(1, 1) = 1;
+        m_frame(2, 2) = 1;
+        Base::set_degree_u(2);
+        Base::set_degree_v(2);
+    }
+
+    std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::EXTRUSION; }
+
+    const Point& get_location() const { return m_location; }
+    void set_location(const Point& p) { m_location = p; }
+
+    const Frame& get_frame() const { return m_frame; }
+    void set_frame(const Frame& f) { m_frame = f; }
+
+    const ProfileType* get_profile() const { return m_profile; }
+    void set_profile(const ProfileType* profile) { m_profile = profile; }
+
+public:
+    Point evaluate(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        const auto p = m_profile->evaluate(u);
+        return m_location + p + m_frame.row(2) * v;
+    }
+
+    Point evaluate_derivative_u(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        return m_profile->evaluate_derivative(u);
+    }
+
+    Point evaluate_derivative_v(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        return m_frame.row(2);
+    }
+
+    Point evaluate_2nd_derivative_uu(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        return m_profile->evaluate_2nd_derivative(u);
+    }
+
+    Point evaluate_2nd_derivative_vv(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        return Point::Zero();
+    }
+
+    Point evaluate_2nd_derivative_uv(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        return Point::Zero();
+    }
+
+    UVPoint inverse_evaluate(const Point& p,
+        const Scalar min_u,
+        const Scalar max_u,
+        const Scalar min_v,
+        const Scalar max_v) const override
+    {
+        assert_valid_profile();
+        UVPoint uv;
+        uv[1] = (p - m_location).dot(m_frame.row(2));
+        uv[1] = std::min(max_v, std::max(min_v, uv[1]));
+        uv[0] = m_profile->approximate_inverse_evaluate(p - m_frame.row(2) * uv[1], min_u, max_u);
+
+        assert(uv[0] >= min_u && uv[0] <= max_u);
+        assert(uv[1] >= min_v && uv[1] <= max_v);
+        return uv;
+    }
+
+    void initialize() override
+    {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        assert_valid_profile();
+        assert(std::abs(m_frame.row(0).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(1).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(2).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
+        assert(std::abs(m_frame.row(1).dot(m_frame.row(2))) < TOL);
+        assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
+        assert(m_u_upper > m_u_lower);
+        assert(m_v_upper > m_v_lower);
+
+        Base::set_periodic_u(m_profile->get_periodic());
+        Base::set_periodic_v(false);
+    }
+
+    Scalar get_u_lower_bound() const override { return m_u_lower; }
+    Scalar get_u_upper_bound() const override { return m_u_upper; }
+    Scalar get_v_lower_bound() const override { return m_v_lower; }
+    Scalar get_v_upper_bound() const override { return m_v_upper; }
+
+    void set_u_lower_bound(Scalar t) { m_u_lower = t; }
+    void set_u_upper_bound(Scalar t) { m_u_upper = t; }
+    void set_v_lower_bound(Scalar t) { m_v_lower = t; }
+    void set_v_upper_bound(Scalar t) { m_v_upper = t; }
+
+public:
+    virtual int get_num_weights_u() const override { return 0; }
+    virtual int get_num_weights_v() const override { return 0; }
+    virtual Scalar get_weight(int i, int j) const override
+    {
+        throw not_implemented_error("ExtrusionPatch patch does not support weight");
+    }
+    virtual void set_weight(int i, int j, Scalar val) override
+    {
+        throw not_implemented_error("ExtrusionPatch patch does not support weight");
+    }
+
+    virtual int get_num_knots_u() const override { return 0; }
+    virtual Scalar get_knot_u(int i) const override
+    {
+        throw not_implemented_error("ExtrusionPatch patch does not support knots");
+    }
+    virtual void set_knot_u(int i, Scalar val) override
+    {
+        throw not_implemented_error("ExtrusionPatch patch does not support knots");
+    }
+
+    virtual int get_num_knots_v() const override { return 0; }
+    virtual Scalar get_knot_v(int i) const override
+    {
+        throw not_implemented_error("ExtrusionPatch patch does not support knots");
+    }
+    virtual void set_knot_v(int i, Scalar val) override
+    {
+        throw not_implemented_error("ExtrusionPatch patch does not support knots");
+    }
+
+public:
+    int num_control_points_u() const override { return 0; }
+
+    int num_control_points_v() const override { return 0; }
+
+    UVPoint get_control_point_preimage(int i, int j) const override
+    {
+        throw not_implemented_error("ExtrusionPatch does not need control points.");
+    }
+
+private:
+    void assert_valid_profile() const
+    {
+        if (m_profile == nullptr) {
+            throw invalid_setting_error("Profile not set!");
+        }
+    }
+
+private:
+    Point m_location;
+    Frame m_frame;
+    const ProfileType* m_profile = nullptr;
+    Scalar m_u_lower = 0;
+    Scalar m_u_upper = 1;
+    Scalar m_v_lower = 0;
+    Scalar m_v_upper = 1;
+};
+
+} // namespace nanospline

--- a/include/nanospline/ExtrusionPatch.h
+++ b/include/nanospline/ExtrusionPatch.h
@@ -101,6 +101,7 @@ public:
     void initialize() override
     {
         constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        (void)TOL; // Avoid warning.
         assert_valid_profile();
         assert(std::abs(m_frame.row(0).squaredNorm() - 1) < TOL);
         assert(std::abs(m_frame.row(1).squaredNorm() - 1) < TOL);

--- a/include/nanospline/Line.h
+++ b/include/nanospline/Line.h
@@ -36,8 +36,7 @@ public:
     }
 
     void initialize() override {
-        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon();
-        assert(m_direction.squaredNorm() > TOL);
+        assert(m_direction.squaredNorm() > std::numeric_limits<Scalar>::epsilon());
     }
 
 public:

--- a/include/nanospline/Line.h
+++ b/include/nanospline/Line.h
@@ -10,7 +10,7 @@ class Line final : public CurveBase<_Scalar, _dim>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    static_assert(_dim > 1, "Dimension must be greater than 1.");
+    static_assert(_dim > 0, "Dimension must be greater than 0.");
     using Base = CurveBase<_Scalar, _dim>;
     using typename Base::Point;
     using typename Base::Scalar;
@@ -22,6 +22,8 @@ public:
         m_direction.setZero();
         m_direction[0] = 1;
     }
+
+    CurveEnum get_curve_type() const override { return CurveEnum::LINE; }
 
     std::unique_ptr<Base> clone() const override
     {

--- a/include/nanospline/Line.h
+++ b/include/nanospline/Line.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <nanospline/CurveBase.h>
+#include <nanospline/Exceptions.h>
+
+namespace nanospline {
+
+template <typename _Scalar, int _dim>
+class Line final : public CurveBase<_Scalar, _dim>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    static_assert(_dim > 1, "Dimension must be greater than 1.");
+    using Base = CurveBase<_Scalar, _dim>;
+    using typename Base::Point;
+    using typename Base::Scalar;
+
+public:
+    Line()
+        : Base()
+    {
+        m_direction.setZero();
+        m_direction[0] = 1;
+    }
+
+    std::unique_ptr<Base> clone() const override
+    {
+        auto ptr = std::make_unique<Line<_Scalar, _dim>>();
+        ptr->set_direction(m_direction);
+        ptr->set_location(m_location);
+        return ptr;
+    }
+
+public:
+    const Point& get_location() const { return m_location; }
+    void set_location(const Point& c) { m_location = c; }
+
+    const Point& get_direction() const { return m_direction; }
+    void set_direction(const Point& d) { m_direction = d; }
+
+    void set_domain_lower_bound(Scalar t) { m_lower = t; }
+    void set_domain_upper_bound(Scalar t) { m_upper = t; }
+
+public:
+    int get_degree() const override { return -1; }
+    bool in_domain(Scalar t) const override { return t >= m_lower && t <= m_upper; }
+    Scalar get_domain_lower_bound() const override { return m_lower; }
+    Scalar get_domain_upper_bound() const override { return m_upper; }
+
+public:
+    Point evaluate(Scalar t) const override { return m_location + t * m_direction; }
+
+    Scalar inverse_evaluate(const Point& p) const override
+    {
+        return (p - m_location).dot(m_direction) / m_direction.squaredNorm();
+    }
+
+    Point evaluate_derivative(Scalar t) const override { return m_direction; }
+
+    Point evaluate_2nd_derivative(Scalar t) const override { return Point::Zero(); }
+
+    Scalar approximate_inverse_evaluate(
+        const Point& p, const Scalar lower, const Scalar upper, const int level = 3) const override
+    {
+        (void)level;
+        Scalar t = inverse_evaluate(p);
+        if (t < lower) return lower;
+        if (t > upper) return upper;
+        return t;
+    }
+
+public:
+    int get_num_control_points() const override { return 0; }
+    Point get_control_point(int) const override
+    {
+        throw not_implemented_error("Line does not support control points.");
+    }
+    void set_control_point(int, const Point&) override
+    {
+        throw not_implemented_error("Line does not support control points.");
+    }
+
+    int get_num_weights() const override { return 0; }
+    Scalar get_weight(int) const override
+    {
+        throw not_implemented_error("Line does not support weights.");
+    }
+    void set_weight(int, Scalar) override
+    {
+        throw not_implemented_error("Line does not support weights.");
+    }
+
+    int get_num_knots() const override { return 0; }
+    Scalar get_knot(int) const override
+    {
+        throw not_implemented_error("Line does not support knots.");
+    }
+    void set_knot(int, Scalar) override
+    {
+        throw not_implemented_error("Line does not support knots.");
+    }
+
+public:
+    std::vector<Scalar> compute_inflections(const Scalar, const Scalar) const override
+    {
+        return {};
+    }
+
+    std::vector<Scalar> reduce_turning_angle(const Scalar, const Scalar) const override
+    {
+        throw not_implemented_error("Turning angle of a Line cannot be reduced.");
+    }
+
+    std::vector<Scalar> compute_singularities(const Scalar, const Scalar) const override
+    {
+        return {};
+    }
+
+private:
+    Point m_location = Point::Zero();
+    Point m_direction;
+    Scalar m_lower = 0;
+    Scalar m_upper = 1;
+};
+
+} // namespace nanospline

--- a/include/nanospline/Line.h
+++ b/include/nanospline/Line.h
@@ -30,7 +30,14 @@ public:
         auto ptr = std::make_unique<Line<_Scalar, _dim>>();
         ptr->set_direction(m_direction);
         ptr->set_location(m_location);
+        ptr->set_domain_lower_bound(m_lower);
+        ptr->set_domain_upper_bound(m_upper);
         return ptr;
+    }
+
+    void initialize() override {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon();
+        assert(m_direction.squaredNorm() > TOL);
     }
 
 public:
@@ -54,7 +61,7 @@ public:
 
     Scalar inverse_evaluate(const Point& p) const override
     {
-        return (p - m_location).dot(m_direction) / m_direction.squaredNorm();
+        return approximate_inverse_evaluate(p, m_lower, m_upper);
     }
 
     Point evaluate_derivative(Scalar t) const override { return m_direction; }
@@ -65,7 +72,7 @@ public:
         const Point& p, const Scalar lower, const Scalar upper, const int level = 3) const override
     {
         (void)level;
-        Scalar t = inverse_evaluate(p);
+        Scalar t = (p - m_location).dot(m_direction) / m_direction.squaredNorm();
         if (t < lower) return lower;
         if (t > upper) return upper;
         return t;

--- a/include/nanospline/Line.h
+++ b/include/nanospline/Line.h
@@ -116,6 +116,16 @@ public:
         return {};
     }
 
+    Scalar get_turning_angle(Scalar t0, Scalar t1) const override
+    {
+        (void)t0;
+        (void)t1;
+        if (_dim != 2) {
+            throw std::runtime_error("Turning angle reduction is for 2D curves only");
+        }
+        return 0;
+    }
+
 private:
     Point m_location = Point::Zero();
     Point m_direction;

--- a/include/nanospline/NURBS.h
+++ b/include/nanospline/NURBS.h
@@ -40,7 +40,10 @@ public:
         combine_rational_Beziers(curves, parameter_bounds);
     }
 
-    std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override {
+    CurveEnum get_curve_type() const override { return CurveEnum::NURBS; }
+
+    std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override
+    {
         return std::make_unique<ThisType>(*this);
     }
 
@@ -81,7 +84,8 @@ public:
     }
 
 public:
-    virtual void set_control_point(int i, const Point& p) override {
+    virtual void set_control_point(int i, const Point& p) override
+    {
         validate_initialization();
         Base::set_control_point(i, p);
 
@@ -92,10 +96,7 @@ public:
 
     virtual int get_num_weights() const override { return Base::get_num_control_points(); }
 
-    virtual Scalar get_weight(int i) const override
-    {
-        return m_weights[i];
-    }
+    virtual Scalar get_weight(int i) const override { return m_weights[i]; }
 
     virtual void set_weight(int i, Scalar val) override
     {
@@ -108,7 +109,8 @@ public:
         m_bspline_homogeneous.set_control_point(i, q);
     }
 
-    virtual void set_knot(int i, Scalar val) override {
+    virtual void set_knot(int i, Scalar val) override
+    {
         Base::set_knot(i, val);
         m_bspline_homogeneous.set_knot(i, val);
     }
@@ -153,8 +155,7 @@ public:
         return {segments, parameter_bounds};
     }
 
-    std::vector<Scalar> compute_inflections(
-        const Scalar lower, const Scalar upper) const override
+    std::vector<Scalar> compute_inflections(const Scalar lower, const Scalar upper) const override
     {
         std::vector<RationalBezier<Scalar, _dim, _degree, _generic>> segments;
         std::vector<Scalar> parameter_bounds;
@@ -207,8 +208,7 @@ public:
         return theta;
     }
 
-    std::vector<Scalar> reduce_turning_angle(
-        const Scalar lower, const Scalar upper) const override
+    std::vector<Scalar> reduce_turning_angle(const Scalar lower, const Scalar upper) const override
     {
         if (_dim != 2) {
             throw std::runtime_error("Turning angle reduction is for 2D curves only");
@@ -248,8 +248,7 @@ public:
         return res;
     }
 
-    std::vector<Scalar> compute_singularities(
-        const Scalar lower, const Scalar upper) const override
+    std::vector<Scalar> compute_singularities(const Scalar lower, const Scalar upper) const override
     {
         if (_dim != 2) {
             throw std::runtime_error("Singularity computation is for 2D curves only");

--- a/include/nanospline/NURBSPatch.h
+++ b/include/nanospline/NURBSPatch.h
@@ -3,6 +3,7 @@
 #include <nanospline/BSplinePatch.h>
 #include <nanospline/NURBS.h>
 #include <nanospline/PatchBase.h>
+#include <nanospline/split.h>
 
 namespace nanospline {
 
@@ -33,7 +34,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
-
+    PatchEnum get_patch_type() const override { return PatchEnum::NURBS; }
 
 public:
     int num_control_points_u() const override { return m_homogeneous.num_control_points_u(); }

--- a/include/nanospline/PatchBase.h
+++ b/include/nanospline/PatchBase.h
@@ -204,9 +204,20 @@ protected:
                 level - 1);
         };
 
+        const Scalar u_range = get_u_upper_bound() - get_u_lower_bound();
+        const Scalar v_range = get_v_upper_bound() - get_v_lower_bound();
+        auto on_opposite_boundary = [&](Scalar u1, Scalar v1, Scalar u2, Scalar v2) {
+            constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+            bool r = false;
+            r |= std::abs(std::abs(u1 - u2) - u_range) < TOL;
+            r |= std::abs(std::abs(v1 - v2) - v_range) < TOL;
+            return r;
+        };
+
         if (level <= 0) {
             return uv;
-        } else if (std::abs(min_dist - min_dist_2) > min_dist * 1e-3) {
+        } else if (std::abs(min_dist - min_dist_2) > min_dist * 1e-3 ||
+                   !on_opposite_boundary(uv[0], uv[1], uv_2[0], uv_2[1])) {
             return check_sub_range(uv[0], uv[1]);
         } else {
             // Handle the case where two uv points are nearly equally close to

--- a/include/nanospline/PatchBase.h
+++ b/include/nanospline/PatchBase.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <nanospline/Exceptions.h>
-#include <nanospline/split.h>
+#include <nanospline/enums.h>
+
 #include <Eigen/Core>
 #include <utility>
 #include <vector>
-
 
 namespace nanospline {
 
@@ -22,6 +22,7 @@ public:
 public:
     virtual ~PatchBase() = default;
     virtual std::unique_ptr<PatchBase> clone() const = 0;
+    virtual PatchEnum get_patch_type() const = 0;
 
 public:
     constexpr int get_dim() const { return _dim; }

--- a/include/nanospline/Plane.h
+++ b/include/nanospline/Plane.h
@@ -30,6 +30,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::PLANE; }
 
     const Point& get_location() const { return m_location; }
     void set_location(const Point& p) { m_location = p; }

--- a/include/nanospline/Plane.h
+++ b/include/nanospline/Plane.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include <nanospline/PatchBase.h>
+
+namespace nanospline {
+
+template <typename _Scalar, int _dim>
+class Plane final : public PatchBase<_Scalar, _dim>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    static_assert(_dim > 0, "Dimension must be positive.");
+
+    using Base = PatchBase<_Scalar, _dim>;
+    using ThisType = Plane<_Scalar, _dim>;
+    using Scalar = typename Base::Scalar;
+    using Point = typename Base::Point;
+    using UVPoint = typename Base::UVPoint;
+    using Frame = Eigen::Matrix<Scalar, 2, _dim>;
+
+public:
+    Plane()
+    {
+        m_location.setZero();
+        m_frame.setZero();
+        m_frame(0, 0) = 1;
+        m_frame(1, 1) = 1;
+        Base::set_degree_u(1);
+        Base::set_degree_v(1);
+    }
+
+    std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+
+    const Point& get_location() const { return m_location; }
+    void set_location(const Point& p) { m_location = p; }
+
+    const Frame& get_frame() const { return m_frame; }
+    void set_frame(const Frame& f) { m_frame = f; }
+
+public:
+    Point evaluate(Scalar u, Scalar v) const override
+    {
+        return m_location + m_frame.row(0) * u + m_frame.row(1) * v;
+    }
+
+    Point evaluate_derivative_u(Scalar u, Scalar v) const override
+    {
+        return m_frame.row(0);
+    }
+
+    Point evaluate_derivative_v(Scalar u, Scalar v) const override
+    {
+        return m_frame.row(1);
+    }
+
+    Point evaluate_2nd_derivative_uu(Scalar u, Scalar v) const override
+    {
+        return Point::Zero();
+    }
+
+    Point evaluate_2nd_derivative_vv(Scalar u, Scalar v) const override
+    {
+        return Point::Zero();
+    }
+
+    Point evaluate_2nd_derivative_uv(Scalar u, Scalar v) const override
+    {
+        return Point::Zero();
+    }
+
+    UVPoint inverse_evaluate(const Point& p,
+        const Scalar min_u,
+        const Scalar max_u,
+        const Scalar min_v,
+        const Scalar max_v) const override
+    {
+        UVPoint uv;
+
+        uv[0] = (p - m_location).dot(m_frame.row(0)) / m_frame.row(0).squaredNorm();
+        uv[1] = (p - m_location).dot(m_frame.row(1)) / m_frame.row(1).squaredNorm();
+
+        uv[0] = std::max(min_u, std::min(uv[0], max_u));
+        uv[1] = std::max(min_v, std::min(uv[1], max_v));
+
+        return uv;
+    }
+
+    void initialize() override
+    {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        assert(m_frame.row(0).squaredNorm() > TOL);
+        assert(m_frame.row(1).squaredNorm() > TOL);
+        assert(m_u_upper > m_u_lower);
+        assert(m_v_upper > m_v_lower);
+    }
+
+    Scalar get_u_lower_bound() const override { return m_u_lower; }
+    Scalar get_u_upper_bound() const override { return m_u_upper; }
+    Scalar get_v_lower_bound() const override { return m_v_lower; }
+    Scalar get_v_upper_bound() const override { return m_v_upper; }
+
+    void set_u_lower_bound(Scalar t) { m_u_lower = t; }
+    void set_u_upper_bound(Scalar t) { m_u_upper = t; }
+    void set_v_lower_bound(Scalar t) { m_v_lower = t; }
+    void set_v_upper_bound(Scalar t) { m_v_upper = t; }
+
+public:
+    virtual int get_num_weights_u() const override { return 0; }
+    virtual int get_num_weights_v() const override { return 0; }
+    virtual Scalar get_weight(int i, int j) const override
+    {
+        throw not_implemented_error("Plane patch does not support weight");
+    }
+    virtual void set_weight(int i, int j, Scalar val) override
+    {
+        throw not_implemented_error("Plane patch does not support weight");
+    }
+
+    virtual int get_num_knots_u() const override { return 0; }
+    virtual Scalar get_knot_u(int i) const override
+    {
+        throw not_implemented_error("Plane patch does not support knots");
+    }
+    virtual void set_knot_u(int i, Scalar val) override
+    {
+        throw not_implemented_error("Plane patch does not support knots");
+    }
+
+    virtual int get_num_knots_v() const override { return 0; }
+    virtual Scalar get_knot_v(int i) const override
+    {
+        throw not_implemented_error("Plane patch does not support knots");
+    }
+    virtual void set_knot_v(int i, Scalar val) override
+    {
+        throw not_implemented_error("Plane patch does not support knots");
+    }
+
+public:
+    int num_control_points_u() const override
+    {
+        return 0;
+    }
+
+    int num_control_points_v() const override
+    {
+        return 0;
+    }
+
+    UVPoint get_control_point_preimage(int i, int j) const override
+    {
+        throw not_implemented_error("Plane does not need control points.");
+    }
+
+private:
+    Point m_location;
+    Frame m_frame;
+    Scalar m_u_lower = 0;
+    Scalar m_u_upper = 1;
+    Scalar m_v_lower = 0;
+    Scalar m_v_upper = 1;
+};
+
+} // namespace nanospline

--- a/include/nanospline/Plane.h
+++ b/include/nanospline/Plane.h
@@ -74,6 +74,7 @@ public:
     void initialize() override
     {
         constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        (void)TOL; // Avoid warning.
         assert(m_frame.row(0).squaredNorm() > TOL);
         assert(m_frame.row(1).squaredNorm() > TOL);
         assert(m_u_upper > m_u_lower);

--- a/include/nanospline/Plane.h
+++ b/include/nanospline/Plane.h
@@ -78,6 +78,8 @@ public:
         assert(m_frame.row(1).squaredNorm() > TOL);
         assert(m_u_upper > m_u_lower);
         assert(m_v_upper > m_v_lower);
+        Base::set_periodic_u(false);
+        Base::set_periodic_v(false);
     }
 
     Scalar get_u_lower_bound() const override { return m_u_lower; }

--- a/include/nanospline/RationalBezier.h
+++ b/include/nanospline/RationalBezier.h
@@ -28,6 +28,8 @@ public:
     using BezierHomogeneous = Bezier<_Scalar, _dim + 1, _degree, _generic>;
 
 public:
+    CurveEnum get_curve_type() const override { return CurveEnum::RATIONAL_BEZIER; }
+
     std::unique_ptr<CurveBase<_Scalar, _dim>> clone() const override
     {
         return std::make_unique<ThisType>(*this);

--- a/include/nanospline/RationalBezierPatch.h
+++ b/include/nanospline/RationalBezierPatch.h
@@ -3,6 +3,7 @@
 #include <nanospline/BezierPatch.h>
 #include <nanospline/PatchBase.h>
 #include <nanospline/RationalBezier.h>
+#include <nanospline/split.h>
 
 namespace nanospline {
 
@@ -32,6 +33,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::BEZIER; }
 
 public:
     int num_control_points_u() const override { return m_homogeneous.num_control_points_u(); }

--- a/include/nanospline/RevolutionPatch.h
+++ b/include/nanospline/RevolutionPatch.h
@@ -136,6 +136,8 @@ public:
         Base::set_periodic_u(m_profile->get_periodic());
         if (m_v_upper - m_v_lower > 2 * M_PI - TOL) {
             Base::set_periodic_v(true);
+        } else {
+            Base::set_periodic_v(false);
         }
     }
 

--- a/include/nanospline/RevolutionPatch.h
+++ b/include/nanospline/RevolutionPatch.h
@@ -1,0 +1,212 @@
+#pragma once
+
+#include <nanospline/PatchBase.h>
+
+namespace nanospline {
+
+template <typename _Scalar, int _dim>
+class RevolutionPatch final : public PatchBase<_Scalar, _dim>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    static_assert(_dim == 3, "Surface of revolution is 3D only.");
+
+    using Base = PatchBase<_Scalar, _dim>;
+    using ThisType = RevolutionPatch<_Scalar, _dim>;
+    using Scalar = typename Base::Scalar;
+    using Point = typename Base::Point;
+    using UVPoint = typename Base::UVPoint;
+    using Frame = Eigen::Matrix<Scalar, 3, _dim>;
+    using ProfileType = CurveBase<_Scalar, _dim>;
+
+public:
+    RevolutionPatch()
+    {
+        m_location.setZero();
+        m_frame.setZero();
+        m_frame(0, 0) = 1;
+        m_frame(1, 1) = 1;
+        m_frame(2, 2) = 1;
+        Base::set_degree_u(2);
+        Base::set_degree_v(2);
+    }
+
+    std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::REVOLUTION; }
+
+    const Point& get_location() const { return m_location; }
+    void set_location(const Point& p) { m_location = p; }
+
+    const Frame& get_frame() const { return m_frame; }
+    void set_frame(const Frame& f) { m_frame = f; }
+
+    const ProfileType* get_profile() const { return m_profile; }
+    void set_profile(const ProfileType* profile) { m_profile = profile; }
+
+public:
+    Point evaluate(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        const auto p = m_profile->evaluate(u);
+        Eigen::AngleAxis<Scalar> R(v, m_frame.row(2));
+        return m_location + (R * (p - m_location).transpose()).transpose();
+    }
+
+    Point evaluate_derivative_u(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        const auto d = m_profile->evaluate_derivative(u);
+        Eigen::AngleAxis<Scalar> R(v, m_frame.row(2));
+        return (R * d.transpose()).transpose();
+    }
+
+    Point evaluate_derivative_v(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        const auto p = evaluate(u, v);
+        Point d = m_frame.row(2).cross(p - m_location);
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        if (d.norm() > TOL) {
+            const Point v = p - m_location;
+            const Scalar r = (v - v.dot(m_frame.row(2)) * m_frame.row(2)).norm();
+            d = d.normalized() * r;
+        }
+        return d;
+    }
+
+    Point evaluate_2nd_derivative_uu(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        const auto d = m_profile->evaluate_2nd_derivative(u);
+        Eigen::AngleAxis<Scalar> R(v, m_frame.row(2));
+        return (R * d.transpose()).transpose();
+    }
+
+    Point evaluate_2nd_derivative_vv(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        const auto p = evaluate(u, v);
+        Point d = p - m_location;
+        return -d + d.dot(m_frame.row(2)) * m_frame.row(2);
+    }
+
+    Point evaluate_2nd_derivative_uv(Scalar u, Scalar v) const override
+    {
+        assert_valid_profile();
+        Point du = evaluate_derivative_u(u, v);
+        Point duv = m_frame.row(2).cross(du);
+
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        if (duv.norm() > TOL) {
+            const Scalar r = (duv - duv.dot(m_frame.row(2)) * m_frame.row(2)).norm();
+            duv = duv.normalized() * r;
+        }
+        return duv;
+    }
+
+    UVPoint inverse_evaluate(const Point& p,
+        const Scalar min_u,
+        const Scalar max_u,
+        const Scalar min_v,
+        const Scalar max_v) const override
+    {
+        assert_valid_profile();
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 100;
+        const int num_samples = std::max(m_profile->get_num_control_points(), 7) + 1;
+        UVPoint uv = Base::approximate_inverse_evaluate(p, num_samples, min_u, max_u, min_v, max_v, 10);
+        uv = Base::newton_raphson(p, uv, 20, TOL, min_u, max_u, min_v, max_v);
+        assert(uv[0] >= min_u && uv[0] <= max_u);
+        assert(uv[1] >= min_v && uv[1] <= max_v);
+        return uv;
+    }
+
+    void initialize() override
+    {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        assert_valid_profile();
+        assert(std::abs(m_frame.row(0).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(1).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(2).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
+        assert(std::abs(m_frame.row(1).dot(m_frame.row(2))) < TOL);
+        assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
+        assert(m_u_upper > m_u_lower);
+        assert(m_v_upper > m_v_lower);
+
+        Base::set_periodic_u(m_profile->get_periodic());
+        if (m_v_upper - m_v_lower > 2 * M_PI - TOL) {
+            Base::set_periodic_v(true);
+        }
+    }
+
+    Scalar get_u_lower_bound() const override { return m_u_lower; }
+    Scalar get_u_upper_bound() const override { return m_u_upper; }
+    Scalar get_v_lower_bound() const override { return m_v_lower; }
+    Scalar get_v_upper_bound() const override { return m_v_upper; }
+
+    void set_u_lower_bound(Scalar t) { m_u_lower = t; }
+    void set_u_upper_bound(Scalar t) { m_u_upper = t; }
+    void set_v_lower_bound(Scalar t) { m_v_lower = t; }
+    void set_v_upper_bound(Scalar t) { m_v_upper = t; }
+
+public:
+    virtual int get_num_weights_u() const override { return 0; }
+    virtual int get_num_weights_v() const override { return 0; }
+    virtual Scalar get_weight(int i, int j) const override
+    {
+        throw not_implemented_error("RevolutionPatch patch does not support weight");
+    }
+    virtual void set_weight(int i, int j, Scalar val) override
+    {
+        throw not_implemented_error("RevolutionPatch patch does not support weight");
+    }
+
+    virtual int get_num_knots_u() const override { return 0; }
+    virtual Scalar get_knot_u(int i) const override
+    {
+        throw not_implemented_error("RevolutionPatch patch does not support knots");
+    }
+    virtual void set_knot_u(int i, Scalar val) override
+    {
+        throw not_implemented_error("RevolutionPatch patch does not support knots");
+    }
+
+    virtual int get_num_knots_v() const override { return 0; }
+    virtual Scalar get_knot_v(int i) const override
+    {
+        throw not_implemented_error("RevolutionPatch patch does not support knots");
+    }
+    virtual void set_knot_v(int i, Scalar val) override
+    {
+        throw not_implemented_error("RevolutionPatch patch does not support knots");
+    }
+
+public:
+    int num_control_points_u() const override { return 0; }
+
+    int num_control_points_v() const override { return 0; }
+
+    UVPoint get_control_point_preimage(int i, int j) const override
+    {
+        throw not_implemented_error("RevolutionPatch does not need control points.");
+    }
+
+private:
+    void assert_valid_profile() const
+    {
+        if (m_profile == nullptr) {
+            throw invalid_setting_error("Profile not set!");
+        }
+    }
+
+private:
+    Point m_location;
+    Frame m_frame;
+    const ProfileType* m_profile = nullptr;
+    Scalar m_u_lower = 0;
+    Scalar m_u_upper = 1;
+    Scalar m_v_lower = 0;
+    Scalar m_v_upper = 2 * M_PI;
+};
+
+} // namespace nanospline

--- a/include/nanospline/Sphere.h
+++ b/include/nanospline/Sphere.h
@@ -31,6 +31,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::SPHERE; }
 
     const Point& get_location() const { return m_location; }
     void set_location(const Point& p) { m_location = p; }

--- a/include/nanospline/Sphere.h
+++ b/include/nanospline/Sphere.h
@@ -96,11 +96,11 @@ public:
         uv[0] = std::atan2(y, x);
         uv[1] = std::atan2(z, std::hypot(x, y));
 
-        if (uv[0] < min_u){
+        if (uv[0] < min_u) {
             int n = static_cast<int>(std::ceil((min_u - uv[0]) / (2 * M_PI)));
             uv[0] += n * 2 * M_PI;
         }
-        if (uv[1] < min_v){
+        if (uv[1] < min_v) {
             int n = static_cast<int>(std::ceil((min_v - uv[1]) / (2 * M_PI)));
             uv[1] += n * 2 * M_PI;
         }
@@ -139,6 +139,13 @@ public:
         assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
         assert(m_u_upper > m_u_lower);
         assert(m_v_upper > m_v_lower);
+
+        Base::set_periodic_u((fmod(m_u_upper - m_u_lower, 2 * M_PI) < TOL));
+        if (std::abs(m_v_lower + M_PI / 2) < TOL && std::abs(m_v_upper - M_PI / 2) < TOL) {
+            Base::set_periodic_v(true);
+        } else {
+            Base::set_periodic_v(false);
+        }
     }
 
     Scalar get_u_lower_bound() const override { return m_u_lower; }

--- a/include/nanospline/Torus.h
+++ b/include/nanospline/Torus.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <nanospline/PatchBase.h>
+
+namespace nanospline {
+
+template <typename _Scalar, int _dim>
+class Torus final : public PatchBase<_Scalar, _dim>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    static_assert(_dim > 2, "Dimension must be larger than 2.");
+
+    using Base = PatchBase<_Scalar, _dim>;
+    using ThisType = Torus<_Scalar, _dim>;
+    using Scalar = typename Base::Scalar;
+    using Point = typename Base::Point;
+    using UVPoint = typename Base::UVPoint;
+    using Frame = Eigen::Matrix<Scalar, 3, _dim>;
+
+public:
+    Torus()
+    {
+        m_location.setZero();
+        m_frame.setZero();
+        m_frame(0, 0) = 1;
+        m_frame(1, 1) = 1;
+        m_frame(2, 2) = 1;
+        Base::set_degree_u(2);
+        Base::set_degree_v(1);
+    }
+
+    std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+
+    const Point& get_location() const { return m_location; }
+    void set_location(const Point& p) { m_location = p; }
+
+    const Frame& get_frame() const { return m_frame; }
+    void set_frame(const Frame& f) { m_frame = f; }
+
+    Scalar get_major_radius() const { return m_major_radius; }
+    void set_major_radius(Scalar r) { m_major_radius = r; }
+
+    Scalar get_minor_radius() const { return m_minor_radius; }
+    void set_minor_radius(Scalar r) { m_minor_radius = r; }
+
+public:
+    Point evaluate(Scalar u, Scalar v) const override
+    {
+        return m_location +
+               (m_major_radius + m_minor_radius * std::cos(v)) *
+                   (std::cos(u) * m_frame.row(0) + std::sin(u) * m_frame.row(1)) +
+               m_minor_radius * std::sin(v) * m_frame.row(2);
+    }
+
+    Point evaluate_derivative_u(Scalar u, Scalar v) const override
+    {
+        return (m_major_radius + m_minor_radius * std::cos(v)) *
+               (-std::sin(u) * m_frame.row(0) + std::cos(u) * m_frame.row(1));
+    }
+
+    Point evaluate_derivative_v(Scalar u, Scalar v) const override
+    {
+        return (-m_minor_radius * std::sin(v)) *
+                   (std::cos(u) * m_frame.row(0) + std::sin(u) * m_frame.row(1)) +
+               m_minor_radius * std::cos(v) * m_frame.row(2);
+    }
+
+    Point evaluate_2nd_derivative_uu(Scalar u, Scalar v) const override
+    {
+        return (m_major_radius + m_minor_radius * std::cos(v)) *
+               (-std::cos(u) * m_frame.row(0) - std::sin(u) * m_frame.row(1));
+    }
+
+    Point evaluate_2nd_derivative_vv(Scalar u, Scalar v) const override
+    {
+        return (-m_minor_radius * std::cos(v)) *
+                   (std::cos(u) * m_frame.row(0) + std::sin(u) * m_frame.row(1)) -
+               m_minor_radius * std::sin(v) * m_frame.row(2);
+    }
+
+    Point evaluate_2nd_derivative_uv(Scalar u, Scalar v) const override
+    {
+        return m_minor_radius * std::sin(v) *
+               (std::sin(u) * m_frame.row(0) - std::cos(u) * m_frame.row(1));
+    }
+
+    UVPoint inverse_evaluate(const Point& p,
+        const Scalar min_u,
+        const Scalar max_u,
+        const Scalar min_v,
+        const Scalar max_v) const override
+    {
+        UVPoint uv;
+        const Scalar x = (p - m_location).dot(m_frame.row(0));
+        const Scalar y = (p - m_location).dot(m_frame.row(1));
+        const Scalar z = (p - m_location).dot(m_frame.row(2));
+        uv[0] = std::atan2(y, x);
+
+        const Scalar w = std::hypot(x, y) - m_major_radius;
+        uv[1] = std::atan2(z, w);
+
+        if (uv[0] < min_u) {
+            int n = static_cast<int>(std::ceil((min_u - uv[0]) / (2 * M_PI)));
+            uv[0] += n * 2 * M_PI;
+        }
+        if (uv[1] < min_v) {
+            int n = static_cast<int>(std::ceil((min_v - uv[1]) / (2 * M_PI)));
+            uv[1] += n * 2 * M_PI;
+        }
+
+        if (uv[0] > max_u) {
+            const Scalar du_min = 2 * M_PI - (uv[0] - min_u);
+            const Scalar du_max = uv[0] - max_u;
+            if (du_min < du_max) {
+                uv[0] = min_u;
+            } else {
+                uv[0] = max_u;
+            }
+        }
+        if (uv[1] > max_v) {
+            const Scalar dv_min = 2 * M_PI - (uv[1] - min_v);
+            const Scalar dv_max = uv[1] - max_v;
+            if (dv_min < dv_max) {
+                uv[1] = min_v;
+            } else {
+                uv[1] = max_v;
+            }
+        }
+
+        return uv;
+    }
+
+    void initialize() override
+    {
+        constexpr Scalar TOL = std::numeric_limits<Scalar>::epsilon() * 10;
+        assert(std::abs(m_frame.row(0).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(1).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(2).squaredNorm() - 1) < TOL);
+        assert(std::abs(m_frame.row(0).dot(m_frame.row(1))) < TOL);
+        assert(std::abs(m_frame.row(1).dot(m_frame.row(2))) < TOL);
+        assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
+        assert(m_u_upper > m_u_lower);
+        assert(m_v_upper > m_v_lower);
+    }
+
+    Scalar get_u_lower_bound() const override { return m_u_lower; }
+    Scalar get_u_upper_bound() const override { return m_u_upper; }
+    Scalar get_v_lower_bound() const override { return m_v_lower; }
+    Scalar get_v_upper_bound() const override { return m_v_upper; }
+
+    void set_u_lower_bound(Scalar t) { m_u_lower = t; }
+    void set_u_upper_bound(Scalar t) { m_u_upper = t; }
+    void set_v_lower_bound(Scalar t) { m_v_lower = t; }
+    void set_v_upper_bound(Scalar t) { m_v_upper = t; }
+
+public:
+    virtual int get_num_weights_u() const override { return 0; }
+    virtual int get_num_weights_v() const override { return 0; }
+    virtual Scalar get_weight(int i, int j) const override
+    {
+        throw not_implemented_error("Torus patch does not support weight");
+    }
+    virtual void set_weight(int i, int j, Scalar val) override
+    {
+        throw not_implemented_error("Torus patch does not support weight");
+    }
+
+    virtual int get_num_knots_u() const override { return 0; }
+    virtual Scalar get_knot_u(int i) const override
+    {
+        throw not_implemented_error("Torus patch does not support knots");
+    }
+    virtual void set_knot_u(int i, Scalar val) override
+    {
+        throw not_implemented_error("Torus patch does not support knots");
+    }
+
+    virtual int get_num_knots_v() const override { return 0; }
+    virtual Scalar get_knot_v(int i) const override
+    {
+        throw not_implemented_error("Torus patch does not support knots");
+    }
+    virtual void set_knot_v(int i, Scalar val) override
+    {
+        throw not_implemented_error("Torus patch does not support knots");
+    }
+
+public:
+    int num_control_points_u() const override { return 0; }
+
+    int num_control_points_v() const override { return 0; }
+
+    UVPoint get_control_point_preimage(int i, int j) const override
+    {
+        throw not_implemented_error("Torus does not need control points.");
+    }
+
+private:
+    Point m_location;
+    Frame m_frame;
+    Scalar m_major_radius = 1;
+    Scalar m_minor_radius = 0.2;
+    Scalar m_u_lower = 0;
+    Scalar m_u_upper = 2 * M_PI;
+    Scalar m_v_lower = 0;
+    Scalar m_v_upper = 2 * M_PI;
+};
+
+} // namespace nanospline

--- a/include/nanospline/Torus.h
+++ b/include/nanospline/Torus.h
@@ -143,6 +143,8 @@ public:
         assert(std::abs(m_frame.row(2).dot(m_frame.row(0))) < TOL);
         assert(m_u_upper > m_u_lower);
         assert(m_v_upper > m_v_lower);
+        Base::set_periodic_u((fmod(m_u_upper - m_u_lower, 2 * M_PI) < TOL));
+        Base::set_periodic_v((fmod(m_v_upper - m_v_lower, 2 * M_PI) < TOL));
     }
 
     Scalar get_u_lower_bound() const override { return m_u_lower; }

--- a/include/nanospline/Torus.h
+++ b/include/nanospline/Torus.h
@@ -31,6 +31,7 @@ public:
     }
 
     std::unique_ptr<Base> clone() const override { return std::make_unique<ThisType>(*this); }
+    PatchEnum get_patch_type() const override { return PatchEnum::TORUS; }
 
     const Point& get_location() const { return m_location; }
     void set_location(const Point& p) { m_location = p; }

--- a/include/nanospline/enums.h
+++ b/include/nanospline/enums.h
@@ -6,7 +6,10 @@ enum class CurveEnum {
     BEZIER = 1,
     RATIONAL_BEZIER = 2,
     BSPLINE = 3,
-    NURBS = 4
+    NURBS = 4,
+    LINE = 5,
+    CIRCLE = 6,
+    ELLIPSE = 7
 };
 
 enum class PatchEnum {

--- a/include/nanospline/enums.h
+++ b/include/nanospline/enums.h
@@ -16,7 +16,14 @@ enum class PatchEnum {
     BEZIER = 1,
     RATIONAL_BEZIER = 2,
     BSPLINE = 3,
-    NURBS = 4
+    NURBS = 4,
+    PLANE = 5,
+    CYLINDER = 6,
+    CONE = 7,
+    SPHERE = 8,
+    TORUS = 9,
+    REVOLUTION = 10,
+    EXTRUSION = 11
 };
 
 enum class SampleMethod {

--- a/include/nanospline/nanospline.h
+++ b/include/nanospline/nanospline.h
@@ -12,6 +12,16 @@
 #include <nanospline/NURBSPatch.h>
 #include <nanospline/RationalBezierPatch.h>
 
+// Curve primitive types.
+#include <nanospline/Line.h>
+#include <nanospline/Circle.h>
+#include <nanospline/Ellipse.h>
+
+// Patch primitive types.
+#include <nanospline/Plane.h>
+#include <nanospline/Cylinder.h>
+#include <nanospline/Sphere.h>
+
 // IO
 #include <nanospline/load_msh.h>
 #include <nanospline/save_msh.h>

--- a/include/nanospline/save_msh.h
+++ b/include/nanospline/save_msh.h
@@ -110,13 +110,7 @@ void add_curve(MshSpec& spec, const CurveType& curve, int tag = 1)
     }
 
     curve_spec.curve_tag = static_cast<size_t>(tag);
-    if (num_knots == 0) {
-        curve_spec.curve_type = static_cast<size_t>(
-            (num_weights == 0) ? CurveEnum::BEZIER : CurveEnum::RATIONAL_BEZIER);
-    } else {
-        curve_spec.curve_type =
-            static_cast<size_t>((num_weights == 0) ? CurveEnum::BSPLINE : CurveEnum::NURBS);
-    }
+    curve_spec.curve_type = static_cast<size_t>(curve.get_curve_type());
     curve_spec.curve_degree = static_cast<size_t>(degree);
     curve_spec.num_control_points = static_cast<size_t>(num_control_points);
     curve_spec.num_knots = static_cast<size_t>(num_knots);

--- a/tests/test_Circle.cpp
+++ b/tests/test_Circle.cpp
@@ -1,0 +1,49 @@
+#include <catch2/catch.hpp>
+
+#include <nanospline/Circle.h>
+#include <nanospline/save_msh.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Circle", "[primitive][circle]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    auto check_circle = [](const auto& curve) {
+        REQUIRE(curve.get_degree() == -1);
+        REQUIRE(curve.is_closed(0, 1e-6));
+        REQUIRE(curve.get_periodic());
+
+        {
+            auto p0 = curve.evaluate(0);
+            auto p1 = curve.evaluate(M_PI);
+            auto p2 = curve.evaluate(2*M_PI);
+            auto c = (p0 + p1) / 2;
+            REQUIRE((p0 - p2).norm() == Approx(0).margin(1e-6));
+            auto p3 = curve.evaluate(M_PI/3);
+            REQUIRE((p3 - c).norm() == Approx((p0 - c).norm()));
+        }
+
+        {
+            validate_derivatives(curve, 10);
+            validate_2nd_derivatives(curve, 10);
+            validate_approximate_inverse_evaluation(curve, 10);
+        }
+    };
+
+    SECTION("2D circle")
+    {
+        Circle<Scalar, 2> curve;
+        curve.set_radius(1);
+        check_circle(curve);
+    }
+
+    SECTION("3D circle")
+    {
+        Circle<Scalar, 3> curve;
+        curve.set_radius(2);
+        curve.set_center({1, 1, 1});
+        check_circle(curve);
+    }
+}

--- a/tests/test_Circle.cpp
+++ b/tests/test_Circle.cpp
@@ -45,4 +45,16 @@ TEST_CASE("Circle", "[primitive][circle]")
         curve.set_center({1, 1, 1});
         check_circle(curve);
     }
+
+    SECTION("Circle arc")
+    {
+        Circle<Scalar, 2> curve;
+        curve.set_radius(1);
+        curve.set_domain_lower_bound(0);
+        curve.set_domain_upper_bound(M_PI);
+
+        REQUIRE(!curve.get_periodic());
+        REQUIRE(!curve.is_closed());
+        REQUIRE(curve.get_turning_angle(0, M_PI) == Approx(M_PI));
+    }
 }

--- a/tests/test_Circle.cpp
+++ b/tests/test_Circle.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch.hpp>
 
 #include <nanospline/Circle.h>
-#include <nanospline/save_msh.h>
 
 #include "validation_utils.h"
 

--- a/tests/test_Circle.cpp
+++ b/tests/test_Circle.cpp
@@ -35,6 +35,7 @@ TEST_CASE("Circle", "[primitive][circle]")
     {
         Circle<Scalar, 2> curve;
         curve.set_radius(1);
+        curve.initialize();
         check_circle(curve);
     }
 
@@ -43,6 +44,7 @@ TEST_CASE("Circle", "[primitive][circle]")
         Circle<Scalar, 3> curve;
         curve.set_radius(2);
         curve.set_center({1, 1, 1});
+        curve.initialize();
         check_circle(curve);
     }
 
@@ -52,6 +54,7 @@ TEST_CASE("Circle", "[primitive][circle]")
         curve.set_radius(1);
         curve.set_domain_lower_bound(0);
         curve.set_domain_upper_bound(M_PI);
+        curve.initialize();
 
         REQUIRE(!curve.get_periodic());
         REQUIRE(!curve.is_closed());

--- a/tests/test_Cone.cpp
+++ b/tests/test_Cone.cpp
@@ -1,0 +1,57 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <nanospline/Cone.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Cone", "[Cone][primitive]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Simple 3D")
+    {
+        Cone<Scalar, 3> patch;
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+
+    SECTION("Paritial Cone")
+    {
+        Cone<Scalar, 3> patch;
+        patch.set_angle(0.2);
+        patch.set_radius(0.0);
+        patch.set_u_lower_bound(2 * M_PI - 1);
+        patch.set_u_upper_bound(2 * M_PI + 1);
+        patch.set_v_lower_bound(0);
+        patch.set_v_upper_bound(100);
+        Eigen::Matrix<Scalar, 3, 3> frame;
+        frame << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+        frame =
+            Eigen::AngleAxis<Scalar>(1, Eigen::Matrix<Scalar, 3, 1>::Ones().normalized()) * frame;
+        patch.set_frame(frame);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+
+        {
+            // Test points on the other side of the cone.
+            auto p = patch.evaluate(M_PI, -1);
+            auto uv = patch.inverse_evaluate(p,
+                patch.get_u_lower_bound(),
+                patch.get_u_upper_bound(),
+                patch.get_v_lower_bound(),
+                patch.get_v_upper_bound());
+            auto q = patch.evaluate(uv[0], uv[1]);
+            REQUIRE(q == patch.get_location());
+        }
+    }
+}

--- a/tests/test_Cylinder.cpp
+++ b/tests/test_Cylinder.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <nanospline/Cylinder.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Cylinder", "[cylinder][primitive]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Simple 3D")
+    {
+        Cylinder<Scalar, 3> patch;
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+
+    SECTION("Paritial cylinder")
+    {
+        Cylinder<Scalar, 3> patch;
+        patch.set_radius(0.5);
+        patch.set_u_lower_bound(2 * M_PI - 1);
+        patch.set_u_upper_bound(2 * M_PI + 1);
+        patch.set_v_lower_bound(-1);
+        patch.set_v_upper_bound(100);
+        Eigen::Matrix<Scalar, 3, 3> frame;
+        frame << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+        frame =
+            Eigen::AngleAxis<Scalar>(1, Eigen::Matrix<Scalar, 3, 1>::Ones().normalized()) * frame;
+        patch.set_frame(frame);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+}

--- a/tests/test_Ellipse.cpp
+++ b/tests/test_Ellipse.cpp
@@ -1,0 +1,38 @@
+#include <catch2/catch.hpp>
+
+#include <nanospline/Ellipse.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Ellipse", "[primitive][ellipse]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    auto check_Ellipse = [](const auto& curve) {
+        REQUIRE(curve.get_degree() == -1);
+        REQUIRE(curve.is_closed(0, 1e-6));
+        REQUIRE(curve.get_periodic());
+
+        validate_derivatives(curve, 10);
+        validate_2nd_derivatives(curve, 10);
+        validate_approximate_inverse_evaluation(curve, 10);
+    };
+
+    SECTION("2D Ellipse")
+    {
+        Ellipse<Scalar, 2> curve;
+        curve.set_major_radius(1);
+        curve.set_minor_radius(0.5);
+        check_Ellipse(curve);
+    }
+
+    SECTION("3D Ellipse")
+    {
+        Ellipse<Scalar, 3> curve;
+        curve.set_major_radius(2);
+        curve.set_minor_radius(0.1);
+        curve.set_center({1, 1, 1});
+        check_Ellipse(curve);
+    }
+}

--- a/tests/test_Ellipse.cpp
+++ b/tests/test_Ellipse.cpp
@@ -9,14 +9,34 @@ TEST_CASE("Ellipse", "[primitive][ellipse]")
     using namespace nanospline;
     using Scalar = double;
 
-    auto check_Ellipse = [](const auto& curve) {
+    auto check_inverse_evaluation_orthogonality = [](const auto& curve, int N) {
+        Scalar R = curve.get_major_radius();
+        for (int i = 0; i <= N; i++) {
+            Scalar theta = (Scalar)i / (Scalar)N *
+                               (curve.get_domain_upper_bound() - curve.get_domain_lower_bound()) +
+                           curve.get_domain_lower_bound();
+            const auto& frame = curve.get_frame();
+            auto p = curve.get_center();
+            p += std::cos(theta) * 1.1 * R * frame.row(0);
+            p += std::sin(theta) * 1.1 * R * frame.row(1);
+
+            auto t = curve.inverse_evaluate(p);
+            auto v1 = (curve.evaluate(t) - p).normalized();
+            auto v2 = curve.evaluate_derivative(t).normalized();
+
+            if (t > curve.get_domain_lower_bound() && t < curve.get_domain_upper_bound()) {
+                REQUIRE(v1.dot(v2) == Approx(0).margin(1e-6));
+            }
+        }
+    };
+
+    auto check_Ellipse = [&](const auto& curve) {
         REQUIRE(curve.get_degree() == -1);
-        REQUIRE(curve.is_closed(0, 1e-6));
-        REQUIRE(curve.get_periodic());
 
         validate_derivatives(curve, 10);
         validate_2nd_derivatives(curve, 10);
         validate_approximate_inverse_evaluation(curve, 10);
+        check_inverse_evaluation_orthogonality(curve, 32);
     };
 
     SECTION("2D Ellipse")
@@ -24,6 +44,21 @@ TEST_CASE("Ellipse", "[primitive][ellipse]")
         Ellipse<Scalar, 2> curve;
         curve.set_major_radius(1);
         curve.set_minor_radius(0.5);
+        curve.initialize();
+        REQUIRE(curve.is_closed(0, 1e-6));
+        REQUIRE(curve.get_periodic());
+        check_Ellipse(curve);
+    }
+
+    SECTION("2D Ellipse Arc")
+    {
+        Ellipse<Scalar, 2> curve;
+        curve.set_major_radius(5);
+        curve.set_minor_radius(0.25);
+        curve.set_center({-2, 1});
+        curve.set_domain_lower_bound(2 * M_PI - 1);
+        curve.set_domain_upper_bound(2 * M_PI + 1);
+        curve.initialize();
         check_Ellipse(curve);
     }
 
@@ -33,6 +68,21 @@ TEST_CASE("Ellipse", "[primitive][ellipse]")
         curve.set_major_radius(2);
         curve.set_minor_radius(0.1);
         curve.set_center({1, 1, 1});
+        curve.initialize();
+        REQUIRE(curve.is_closed(0, 1e-6));
+        REQUIRE(curve.get_periodic());
+        check_Ellipse(curve);
+    }
+
+    SECTION("3D Ellipse Arc")
+    {
+        Ellipse<Scalar, 3> curve;
+        curve.set_major_radius(100);
+        curve.set_minor_radius(0.01);
+        curve.set_center({1e-12, -100, 300});
+        curve.set_domain_lower_bound(M_PI);
+        curve.set_domain_upper_bound(2*M_PI);
+        curve.initialize();
         check_Ellipse(curve);
     }
 }

--- a/tests/test_ExtrusionPatch.cpp
+++ b/tests/test_ExtrusionPatch.cpp
@@ -1,0 +1,54 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <nanospline/Bezier.h>
+#include <nanospline/Circle.h>
+#include <nanospline/ExtrusionPatch.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("ExtrusionPatch", "[extrusion_patch][primitive]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Simple")
+    {
+        Eigen::Matrix<Scalar, 4, 3> control_pts;
+        control_pts << 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 2.0, 0.0, 0.0, 3.0, 0.0;
+        Bezier<Scalar, 3, 3> profile;
+        profile.set_control_points(control_pts);
+
+        ExtrusionPatch<Scalar, 3> patch;
+        patch.set_profile(&profile);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+
+    SECTION("Cylinder")
+    {
+        Circle<Scalar, 3> profile;
+        Eigen::Matrix<Scalar, 2, 3> frame;
+        frame << 1, 0, 0,
+                 0, 1, 0;
+        profile.set_frame(frame);
+        profile.set_radius(0.2);
+        profile.set_center({0, 0, 0});
+        profile.initialize();
+
+        ExtrusionPatch<Scalar, 3> patch;
+        patch.set_profile(&profile);
+        patch.set_u_upper_bound(M_PI);
+        patch.set_v_upper_bound(10);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+}

--- a/tests/test_Line.cpp
+++ b/tests/test_Line.cpp
@@ -1,0 +1,43 @@
+#include <catch2/catch.hpp>
+
+#include <nanospline/Line.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Line", "[primitive][line]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    auto check_line = [](const auto& curve) {
+        REQUIRE(curve.get_degree() == -1);
+        REQUIRE(!curve.is_closed(0, 1e-6));
+        REQUIRE(!curve.get_periodic());
+
+        {
+            validate_derivatives(curve, 10);
+            validate_2nd_derivatives(curve, 10);
+            validate_approximate_inverse_evaluation(curve, 10);
+        }
+    };
+
+    SECTION("2D line")
+    {
+        Line<Scalar, 2> curve;
+        curve.set_location({1, 1});
+        curve.set_direction({1, 0});
+        curve.set_domain_lower_bound(1);
+        curve.set_domain_upper_bound(10);
+        check_line(curve);
+    }
+
+    SECTION("3D line")
+    {
+        Line<Scalar, 3> curve;
+        curve.set_location({0, 0, 0});
+        curve.set_direction({1, 0, 1});
+        curve.set_domain_lower_bound(1);
+        curve.set_domain_upper_bound(2);
+        check_line(curve);
+    }
+}

--- a/tests/test_Plane.cpp
+++ b/tests/test_Plane.cpp
@@ -1,0 +1,39 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <nanospline/Plane.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Plane", "[plane]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Simple 3D")
+    {
+        Plane<Scalar, 3> patch;
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+
+    SECTION("Simple 2D")
+    {
+        Plane<Scalar, 2> patch;
+        patch.set_u_lower_bound(-1);
+        patch.set_u_upper_bound(1);
+        patch.set_location({-1, -1});
+        Eigen::Matrix<Scalar, 2, 2> frame;
+        frame << 0, 1, -2, 0;
+        patch.set_frame(frame);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 2);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+    }
+}

--- a/tests/test_Plane.cpp
+++ b/tests/test_Plane.cpp
@@ -5,7 +5,7 @@
 
 #include "validation_utils.h"
 
-TEST_CASE("Plane", "[plane]")
+TEST_CASE("Plane", "[plane][primitive]")
 {
     using namespace nanospline;
     using Scalar = double;

--- a/tests/test_RevolutionPatch.cpp
+++ b/tests/test_RevolutionPatch.cpp
@@ -1,0 +1,52 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <nanospline/Bezier.h>
+#include <nanospline/Circle.h>
+#include <nanospline/RevolutionPatch.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("RevolutionPatch", "[revolution_patch][primitive]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Simple")
+    {
+        Eigen::Matrix<Scalar, 4, 3> control_pts;
+        control_pts << 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 2.0, 0.0, 0.0, 3.0, 0.0;
+        Bezier<Scalar, 3, 3> profile;
+        profile.set_control_points(control_pts);
+
+        RevolutionPatch<Scalar, 3> patch;
+        patch.set_profile(&profile);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10, {0, 1, 0, 2 * M_PI - 0.1});
+    }
+
+    SECTION("Torus")
+    {
+        Circle<Scalar, 3> profile;
+        Eigen::Matrix<Scalar, 2, 3> frame;
+        frame << 0, 0, 1,
+                 0, 1, 0;
+        profile.set_frame(frame);
+        profile.set_radius(0.2);
+        profile.set_center({0, 1, 0});
+        profile.initialize();
+
+        RevolutionPatch<Scalar, 3> patch;
+        patch.set_profile(&profile);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10, {0, 1, 0, 2 * M_PI - 0.1});
+    }
+}

--- a/tests/test_Sphere.cpp
+++ b/tests/test_Sphere.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <nanospline/Sphere.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Sphere", "[sphere][primitive]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Simple 3D")
+    {
+        Sphere<Scalar, 3> patch;
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+
+    SECTION("Paritial sphere")
+    {
+        Sphere<Scalar, 3> patch;
+        patch.set_radius(0.5);
+        patch.set_u_lower_bound(2 * M_PI - 1);
+        patch.set_u_upper_bound(2 * M_PI + 1);
+        patch.set_v_lower_bound(-1);
+        patch.set_v_upper_bound(1);
+        Eigen::Matrix<Scalar, 3, 3> frame;
+        frame << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+        frame =
+            Eigen::AngleAxis<Scalar>(1, Eigen::Matrix<Scalar, 3, 1>::Ones().normalized()) * frame;
+        patch.set_frame(frame);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+}

--- a/tests/test_Sphere.cpp
+++ b/tests/test_Sphere.cpp
@@ -39,6 +39,6 @@ TEST_CASE("Sphere", "[sphere][primitive]")
 
         validate_derivative(patch, 10, 10);
         validate_inverse_evaluation(patch, 10, 10);
-        validate_inverse_evaluation_3d(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10, {-M_PI + 0.1, M_PI - 0.1, -1.1, 1.1});
     }
 }

--- a/tests/test_Torus.cpp
+++ b/tests/test_Torus.cpp
@@ -1,0 +1,45 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <nanospline/Torus.h>
+
+#include "validation_utils.h"
+
+TEST_CASE("Torus", "[Torus][primitive]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Simple 3D")
+    {
+        Torus<Scalar, 3> patch;
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+
+    SECTION("Paritial Torus")
+    {
+        Torus<Scalar, 3> patch;
+        patch.set_major_radius(10.0);
+        patch.set_minor_radius(1.0);
+        patch.set_u_lower_bound(2 * M_PI - 1);
+        patch.set_u_upper_bound(2 * M_PI + 1);
+        patch.set_v_lower_bound(M_PI - 1);
+        patch.set_v_upper_bound(M_PI + 1);
+        Eigen::Matrix<Scalar, 3, 3> frame;
+        frame << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+        frame =
+            Eigen::AngleAxis<Scalar>(1, Eigen::Matrix<Scalar, 3, 1>::Ones().normalized()) * frame;
+        patch.set_frame(frame);
+        patch.initialize();
+        REQUIRE(patch.get_dim() == 3);
+
+        validate_derivative(patch, 10, 10);
+        validate_inverse_evaluation(patch, 10, 10);
+        validate_inverse_evaluation_3d(patch, 10, 10);
+    }
+}

--- a/tests/test_sample.cpp
+++ b/tests/test_sample.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include <nanospline/nanospline.h>
 #include <nanospline/sample.h>
 
 TEST_CASE("sample", "[sample]") {

--- a/tests/validation_utils.h
+++ b/tests/validation_utils.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <nanospline/hodograph.h>
 #include <nanospline/PatchBase.h>
+#include <nanospline/hodograph.h>
 #include <Eigen/Core>
 #include <catch2/catch.hpp>
 #include <limits>
@@ -427,6 +427,19 @@ void validate_inverse_evaluation_3d(const PatchType& patch, int u_samples, int v
     const auto u_max = patch.get_u_upper_bound();
     const auto v_min = patch.get_v_lower_bound();
     const auto v_max = patch.get_v_upper_bound();
+    validate_inverse_evaluation_3d(patch, u_samples, v_samples, {u_min, u_max, v_min, v_max});
+}
+
+template <typename PatchType>
+void validate_inverse_evaluation_3d(const PatchType& patch,
+    int u_samples,
+    int v_samples,
+    const std::array<typename PatchType::Scalar, 4>& domain)
+{
+    const auto u_min = domain[0];
+    const auto u_max = domain[1];
+    const auto v_min = domain[2];
+    const auto v_max = domain[3];
 
     for (int i = 0; i <= u_samples; i++) {
         for (int j = 0; j <= v_samples; j++) {

--- a/tests/validation_utils.h
+++ b/tests/validation_utils.h
@@ -450,6 +450,10 @@ void validate_inverse_evaluation_3d(const PatchType& patch,
             auto q_u = patch.evaluate_derivative_u(u, v);
             auto q_v = patch.evaluate_derivative_v(u, v);
             auto n = q_u.cross(q_v);
+            if (n.norm() < 1e-12) {
+                // Singular pt. Skipping for now.
+                continue;
+            }
             n = n / n.norm();
             q = q + .05 * n;
             const auto uv = patch.inverse_evaluate(q, u_min, u_max, v_min, v_max);


### PR DESCRIPTION
Summary:
* Add support (evaluation, derivative evaluation, inverse evaluation) for common 2D and 3D primitives:
  * 2D: line circle, ellipse.
  * 3D: plane, cylinder, cone, torus, sphere, surface of revolution, surface of extrusion.