### PR TITLE
Update Catch2 to the latest upstream to allow building for Apple silicon

### DIFF
--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -4,7 +4,7 @@ if (NOT TARGET Catch2::Catch2)
     FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v2.11.3
+        GIT_TAG        v2.13.6
         GIT_SHALLOW TRUE
     )
 


### PR DESCRIPTION
The latest Catch2 upstream supports Apple silicon. When this dependency is updated, nanospline will also successfully build for Apple silicon

To build once updated:

mkdir build
cd build
cmake ..
cmake --build .
ctest
100% tests passed, 0 tests failed out of 47