### PR TITLE
Curve-patch intersection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following functionalities are covered:
 * [Turning angle](#Turning-angle)
 * [Singularity](#Singularity)
 * [Conversion](#Conversion)
+* [Intersection](#Intersection)
 
 ### Data structure
 
@@ -343,7 +344,7 @@ points.
 ### Turning angle
 
 Turning angle is the total curvature of a given curve.  It represents how much a
-curve is bending.  In nanospline, turning angle computation is supported for 2D
+curve is bending.  In Nanospline, turning angle computation is supported for 2D
 curves:
 
 ```c++
@@ -435,6 +436,78 @@ try {
 } catch (const std::exception& e) {
     ...
 }
+```
+
+### Intersection
+
+Nanospline supports 3 forms of curve-patch intersection computation:
+
+#### Generic curve-patch intersection
+
+This is the most general form:
+
+```c++
+#include <nanospline/intersect.h>
+
+Scalar t, u, v;
+bool convergdd;
+
+std::tie(t, u, v, converged) = nanospline::intersect(
+    curve,           ///< Input curve.
+    patch,           ///< Input patch.
+    t0,              ///< Initial guess of the intersection on curve.
+    u0, v0,          ///< Initial guess of the intersection on patch.
+    num_iterations,  ///< Max num iterations.
+    tolerance);      ///< Convergence tolerance.
+```
+
+The `converged` flag will be false if the intersection computation fails.
+Typical causes are either the input curve does not intersect the input patch or
+the initial guesses are too off that cause Newton iterations to diverge.
+
+#### Curve-plane intersection
+
+If the patch is actually a plane, Nanospline offers a faster intersection
+computation:
+
+```c++
+#include <nanospline/intersect.h>
+
+std::array<Scalar, 4> plane; // Coefficients of the plane equation.
+                             // i.e. [a,b,c,d] -> ax + by + cz + d = 0.
+Scalar t;
+bool converged;
+
+std::tie(t, converged) = nanospline::intersect(
+    curve,          ///< Input curve.
+    plane,          ///< Plane eqquation coefficients.
+    t0,             ///< Initial guess of the intersection on curve.
+    num_iterations, ///< Max num iterations.
+    tolerance);     ///< Convergence tolerance.
+```
+
+#### Embedded curve and plane intersection
+
+Lastly, it is sometimes necessary to compute the intersection of a curve
+embedded in a patch that is the image of a straight line in parametric space
+and a plane:
+
+```c++
+#include <nanospline/intersect.h>
+
+std::array<Scalar, 4> plane; // Coefficients of the plane equation.
+                             // i.e. [a,b,c,d] -> ax + by + cz + d = 0.
+Scalar u, v;
+bool converged;
+
+std::tie(u, v, converged) = nanospline::intersect(
+    patch,          ///< The patch that contains the curve.
+    pu, pv,         ///< The uv coordinate of the starting point.
+    qu, qv,         ///< The uv coordinate of the end point.
+    plane,          ///< Plane eqquation coefficients.
+    u0, v0,         ///< Initial guess of the intersection on curve.
+    num_iterations, ///< Max num iterations.
+    tolerance);     ///< Convergence tolerance.
 ```
 
 [The NURBS Book]: https://www.springer.com/gp/book/9783642973857

--- a/include/nanospline/intersect.h
+++ b/include/nanospline/intersect.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <nanospline/CurveBase.h>
+#include <nanospline/PatchBase.h>
+
+#include <array>
+#include <limits>
+
+namespace nanospline {
+
+/**
+ * Compute curve-plane intersection using Newton's method.
+ *
+ * @param[in]  curve  Input 3D curve.
+ * @param[in]  plane  Coefficients [a,b,c,d] of a 3D plane equation: ax+by+cz+d=0.
+ * @param[in]  t0     Initial guess of the intersection on the input curve.
+ * @param[in]  num_iterations  The max number of iterations to use.
+ * @param[in]  tol    The distance tolerance for determining convergence.
+ *
+ * @return [t, converged],where the parametric value t representing the curve-plane intersection,
+ * and converged indicates whether the Newton iterations have converged.
+ */
+template <typename Scalar>
+auto intersect(const CurveBase<Scalar, 3>& curve,
+    const std::array<Scalar, 4>& plane,
+    Scalar t0,
+    int num_iterations,
+    Scalar tol) -> std::tuple<Scalar, bool>
+{
+    Scalar prev_t = t0;
+    Scalar t = t0;
+    Scalar prev_err = std::numeric_limits<Scalar>::max();
+    for (int i = 0; i < num_iterations; i++) {
+        const auto d0 = curve.evaluate(t);
+        Scalar err = plane[0] * d0[0] + plane[1] * d0[1] + plane[2] * d0[2] + plane[3];
+        if (std::abs(err) < tol) return {t, true};
+        if (std::abs(err) > prev_err) {
+            return {prev_t, false};
+        }
+
+        prev_err = std::abs(err);
+        prev_t = t;
+
+        const auto d1 = curve.evaluate_derivative(t);
+        Scalar err_derivative = plane[0] * d1[0] + plane[1] * d1[1] + plane[2] * d1[2];
+        t = t - err / err_derivative;
+
+        if (!std::isfinite(t)) {
+            // In case err_derivative is near zero and cause numerical problems.
+            return {prev_t, false};
+        }
+    }
+
+    return {t, false};
+}
+
+/**
+ * Compute implicit curve-plane intersection using Newton's method.  The input
+ * curve is defined as the image of a line segment in UV space on a patch.
+ *
+ * @param[in]  patch  Input 3D patch.
+ * @param[in]  pu,pv  Starting UV point of the curve.
+ * @param[in]  qu,qv  Ending UV point of the curve.
+ * @param[in]  plane  Coefficients [a,b,c,d] of a 3D plane equation: ax+by+cz+d=0.
+ * @param[in]  u0,v0  Initial guess of the intersection on the input curve.
+ * @param[in]  num_iterations  The max number of iterations to use.
+ * @param[in]  tol    The distance tolerance for determining convergence.
+ *
+ * @return [u,v,converged] where [u,v] is the parametric values representing the
+ * curve-plane intersection, and `converged` indicate whether the Newton
+ * iterations have converged.
+ */
+template <typename Scalar>
+auto intersect(const PatchBase<Scalar, 3>& patch,
+    Scalar pu,
+    Scalar pv,
+    Scalar qu,
+    Scalar qv,
+    const std::array<Scalar, 4>& plane,
+    Scalar u0,
+    Scalar v0,
+    int num_iterations,
+    Scalar tol) -> std::tuple<Scalar, Scalar, bool>
+{
+    using Point = typename PatchBase<Scalar, 3>::Point;
+
+    auto interpolate = [&](Scalar t) -> std::array<Scalar, 2> {
+        return {pu * (1 - t) + qu * t, pv * (1 - t) + qv * t};
+    };
+
+    if (std::abs(pu - qu) < 1e-12 && std::abs(pv - qv) < 1e-12) {
+        // Curve degenerates to a point.  Simply check if it is on the line.
+        Point p = patch.evaluate(pu, pv);
+        Scalar err = plane[0] * p[0] + plane[1] * p[1] + plane[2] * p[2] + plane[3];
+        if (err < tol)
+            return {pu, pv, true};
+        else
+            return {pu, pv, false};
+    }
+
+    Scalar prev_t = 1 - std::hypot(u0 - pu, v0 - pv) / std::hypot(pu - qu, pv - qv);
+    Scalar t = prev_t;
+    Scalar u, v;
+    Scalar prev_err = std::numeric_limits<Scalar>::max();
+    Point d0, d1, du, dv;
+
+    for (int i = 0; i < num_iterations; i++) {
+        std::tie(u, v) = interpolate(t);
+
+        d0 = patch.evaluate(u, v);
+        Scalar err = plane[0] * d0[0] + plane[1] * d0[1] + plane[2] * d0[2] + plane[3];
+        if (std::abs(err) < tol) return {u, v, true};
+        if (std::abs(err) > prev_err) {
+            std::tie(u, v) = interpolate(prev_t);
+            return {u, v, false};
+        }
+
+        prev_err = std::abs(err);
+        prev_t = t;
+
+        du = patch.evaluate_derivative_u(u, v);
+        dv = patch.evaluate_derivative_v(u, v);
+        d1 = du * (qu - pu) + dv * (qv - pv);
+
+        Scalar err_derivative = plane[0] * d1[0] + plane[1] * d1[1] + plane[2] * d1[2];
+        t = t - err / err_derivative;
+        if (!std::isfinite(t)) {
+            // In case err_derivative is near zero and cause numerical problems.
+            std::tie(u, v) = interpolate(prev_t);
+            return {u, v, false};
+        }
+    }
+
+    return {u, v, false};
+}
+
+/**
+ * Compute intersection of a generic curve and a generic patch.
+ *
+ * @param[in]  curve  Input curve.
+ * @param[in]  patch  Input patch.
+ * @param[in]  t0     Initial guess of intersection on curve.
+ * @param[in]  u0,v0  Initial guess of intersection on patch.
+ * @param[in]  num_interation  The max number of iterations to use.
+ * @param[in]  tol    The distance tolerance for determining convergence.
+ *
+ * @return A tuple [t, u, v, converged], where t, and (u,v) represents the
+ * intersection on curve and patch respectively, and `converged` indicates
+ * whether the Newton iterations have converged.
+ */
+template <typename Scalar>
+auto intersect(const CurveBase<Scalar, 3>& curve,
+    const PatchBase<Scalar, 3>& patch,
+    Scalar t0,
+    Scalar u0,
+    Scalar v0,
+    int num_iterations,
+    Scalar tol) -> std::tuple<Scalar, Scalar, Scalar, bool>
+{
+    using Vector = Eigen::Matrix<Scalar, 3, 1>;
+    using Matrix = Eigen::Matrix<Scalar, 3, 3>;
+
+    auto evaluate_objective_and_derivatives =
+        [&](Scalar t, Scalar u, Scalar v) -> std::tuple<Scalar, Vector, Matrix> {
+        auto c = curve.evaluate(t);
+        auto p = patch.evaluate(u, v);
+        auto l = c - p;
+
+        auto dt = curve.evaluate_derivative(t);
+        auto du = patch.evaluate_derivative_u(u, v);
+        auto dv = patch.evaluate_derivative_v(u, v);
+
+        auto dtt = curve.evaluate_2nd_derivative(t);
+        auto duu = patch.evaluate_2nd_derivative_uu(u, v);
+        auto duv = patch.evaluate_2nd_derivative_uv(u, v);
+        auto dvv = patch.evaluate_2nd_derivative_vv(u, v);
+
+        Matrix H;
+        H(0, 0) = dtt.dot(l) + dt.squaredNorm();
+        H(0, 1) = -dt.dot(du);
+        H(0, 2) = -dt.dot(dv);
+        H(1, 0) = H(0, 1);
+        H(1, 1) = duu.dot(-l) + du.squaredNorm();
+        H(1, 2) = duv.dot(-l) + du.dot(dv);
+        H(2, 0) = H(0, 2);
+        H(2, 1) = H(1, 2);
+        H(2, 2) = dvv.dot(-l) + dv.squaredNorm();
+
+        Scalar f = l.squaredNorm();
+        Vector g(dt.dot(l), -du.dot(l), -dv.dot(l));
+        return {f, g, H};
+    };
+
+    Scalar t = t0, prev_t = t0;
+    Scalar u = u0, prev_u = u0;
+    Scalar v = v0, prev_v = v0;
+    Scalar f, prev_f = std::numeric_limits<Scalar>::max();
+    Vector g;
+    Matrix H;
+    for (int i = 0; i < num_iterations; i++) {
+        std::tie(f, g, H) = evaluate_objective_and_derivatives(t, u, v);
+        if (f > prev_f) {
+            return {prev_t, prev_u, prev_v, false};
+        }
+        if (f < tol * tol) {
+            return {t, u, v, true};
+        }
+
+        prev_t = t;
+        prev_u = u;
+        prev_v = v;
+        prev_f = f;
+
+        Vector delta = H.inverse() * (-g);
+        if (!delta.array().isFinite().all()) {
+            return {prev_t, prev_u, prev_v, false};
+        }
+        t += delta[0];
+        u += delta[1];
+        v += delta[2];
+    }
+
+    return {t, u, v, false};
+}
+
+} // namespace nanospline

--- a/include/nanospline/intersect.h
+++ b/include/nanospline/intersect.h
@@ -84,7 +84,7 @@ auto intersect(const PatchBase<Scalar, 3>& patch,
 {
     using Point = typename PatchBase<Scalar, 3>::Point;
 
-    auto interpolate = [&](Scalar t) -> std::array<Scalar, 2> {
+    auto interpolate = [&](Scalar t) -> std::tuple<Scalar, Scalar> {
         return {pu * (1 - t) + qu * t, pv * (1 - t) + qv * t};
     };
 

--- a/include/nanospline/intersect.h
+++ b/include/nanospline/intersect.h
@@ -100,7 +100,7 @@ auto intersect(const PatchBase<Scalar, 3>& patch,
 
     Scalar prev_t = 1 - std::hypot(u0 - pu, v0 - pv) / std::hypot(pu - qu, pv - qv);
     Scalar t = prev_t;
-    Scalar u, v;
+    Scalar u = u0, v = v0;
     Scalar prev_err = std::numeric_limits<Scalar>::max();
     Point d0, d1, du, dv;
 

--- a/include/nanospline/nanospline.h
+++ b/include/nanospline/nanospline.h
@@ -13,19 +13,19 @@
 #include <nanospline/RationalBezierPatch.h>
 
 // Curve primitive types.
-#include <nanospline/Line.h>
 #include <nanospline/Circle.h>
 #include <nanospline/Ellipse.h>
+#include <nanospline/Line.h>
 
 // Patch primitive types.
-#include <nanospline/Plane.h>
-#include <nanospline/Cylinder.h>
 #include <nanospline/Cone.h>
-#include <nanospline/Sphere.h>
-#include <nanospline/Torus.h>
-#include <nanospline/RevolutionPatch.h>
+#include <nanospline/Cylinder.h>
 #include <nanospline/ExtrusionPatch.h>
 #include <nanospline/OffsetPatch.h>
+#include <nanospline/Plane.h>
+#include <nanospline/RevolutionPatch.h>
+#include <nanospline/Sphere.h>
+#include <nanospline/Torus.h>
 
 // IO
 #include <nanospline/load_msh.h>
@@ -37,5 +37,6 @@
 #include <nanospline/arc_length.h>
 #include <nanospline/conversion.h>
 #include <nanospline/hodograph.h>
+#include <nanospline/intersect.h>
 #include <nanospline/sample.h>
 #include <nanospline/split.h>

--- a/tests/test_intersect.cpp
+++ b/tests/test_intersect.cpp
@@ -1,0 +1,466 @@
+#include <catch2/catch.hpp>
+
+#include <nanospline/forward_declaration.h>
+#include <nanospline/nanospline.h>
+#include "validation_utils.h"
+
+TEST_CASE("Curve-plane intersect", "[intersect]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    Scalar t;
+    bool converged;
+
+    SECTION("Line-plane")
+    {
+        Line<Scalar, 3> line;
+
+        SECTION("case 1")
+        {
+            line.set_location({0, 0, 0});
+            line.set_direction({1, 1, 1});
+        }
+        SECTION("case 2")
+        {
+            line.set_location({0.5, 0, 0});
+            line.set_direction({1, 1, 1});
+        }
+        SECTION("case 3")
+        {
+            line.set_location({5, 5, 5});
+            line.set_direction({1, 1, 1});
+        }
+
+        line.initialize();
+        std::array<Scalar, 4> plane{1, 1, 1, -1};
+
+        std::tie(t, converged) = intersect(line, plane, 0., 10, 1e-3);
+        REQUIRE(converged);
+        auto p = line.evaluate(t);
+
+        REQUIRE(p.sum() == Approx(1).margin(1e-3));
+    }
+
+    SECTION("Parallel")
+    {
+        Line<Scalar, 3> line;
+        line.set_location({1, 1, 1});
+        line.set_direction({1, 0, 0});
+        line.initialize();
+
+        std::array<Scalar, 4> plane{0, 1, 0, 0};
+        std::tie(t, converged) = intersect(line, plane, 0., 10, 1e-3);
+        REQUIRE_FALSE(converged);
+    }
+
+    SECTION("Circle-plane")
+    {
+        Circle<Scalar, 3> circle;
+        circle.set_center({0, 0, 0});
+        circle.set_radius(1);
+        circle.initialize();
+        std::array<Scalar, 4> plane{1, 1, 1, -1};
+
+        Scalar t0, t1, t2, t3;
+        std::tie(t0, converged) = intersect(circle, plane, 0., 10, 1e-3);
+        REQUIRE(converged);
+        std::tie(t1, converged) = intersect(circle, plane, M_PI / 2, 10, 1e-3);
+        REQUIRE(converged);
+        std::tie(t2, converged) = intersect(circle, plane, 0.1, 10, 1e-3);
+        REQUIRE(converged);
+        std::tie(t3, converged) = intersect(circle, plane, 1.5, 10, 1e-3);
+        REQUIRE(converged);
+
+        REQUIRE(t0 == Approx(0).margin(1e-3));
+        REQUIRE(t1 == Approx(M_PI / 2).margin(1e-3));
+        REQUIRE(t2 == Approx(0).margin(1e-3));
+        REQUIRE(t3 == Approx(M_PI / 2).margin(1e-3));
+
+        SECTION("No intersections")
+        {
+            std::tie(t, converged) = intersect(circle, {1, 1, 1, 2}, 0., 10, 1e-3);
+            REQUIRE_FALSE(converged);
+        }
+    }
+
+    SECTION("Degenerate curve")
+    {
+        Circle<Scalar, 3> circle;
+        circle.set_center({1, 0, 0});
+        circle.set_radius(0);
+        circle.initialize();
+
+        SECTION("Do intersect")
+        {
+            std::array<Scalar, 4> plane{1, 1, 1, -1};
+            std::tie(t, converged) = intersect(circle, plane, 0., 10, 1e-3);
+            REQUIRE(converged);
+        }
+
+        SECTION("Do not intersect")
+        {
+            std::array<Scalar, 4> plane{1, 1, 1, -2};
+            std::tie(t, converged) = intersect(circle, plane, 0., 10, 1e-3);
+            REQUIRE_FALSE(converged);
+        }
+    }
+
+    SECTION("Tangent")
+    {
+        Circle<Scalar, 3> circle;
+        circle.set_center({0, 0, 0});
+        circle.set_radius(1);
+        circle.initialize();
+        std::array<Scalar, 4> plane{1, 0, 0, -1};
+
+        SECTION("Initial guess is the solution")
+        {
+            std::tie(t, converged) = intersect(circle, plane, 0., 10, 1e-3);
+            REQUIRE(converged);
+            REQUIRE(t == Approx(0).margin(1e-3));
+        }
+        SECTION("Initial guess is near the solution")
+        {
+            // Because the tangency, the tolerance needs to be smaller to get
+            // an accurate solution.
+            std::tie(t, converged) = intersect(circle, plane, 0.1, 10, 1e-6);
+            REQUIRE(converged);
+            REQUIRE(t == Approx(0).margin(1e-3));
+        }
+        SECTION("Initial guess is far from the solution")
+        {
+            // Need larger number of iteration and crazy small tolerance to
+            // work.
+            std::tie(t, converged) = intersect(circle, plane, M_PI / 2, 100, 1e-12);
+            REQUIRE(converged);
+            REQUIRE(t == Approx(0).margin(1e-3));
+        }
+    }
+
+    SECTION("Nearly Tangent but not touching")
+    {
+        Circle<Scalar, 3> circle;
+        circle.set_center({0, 0, 0});
+        circle.set_radius(1);
+        circle.initialize();
+        std::array<Scalar, 4> plane{1, 0, 0, -1.001};
+
+        std::tie(t, converged) = intersect(circle, plane, 0., 10, 1e-6);
+        REQUIRE_FALSE(converged);
+        std::tie(t, converged) = intersect(circle, plane, 0.1, 10, 1e-6);
+        REQUIRE_FALSE(converged);
+    }
+
+    SECTION("Generic 3D curve")
+    {
+        Eigen::Matrix<Scalar, 4, 3> control_pts;
+        control_pts << 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0;
+        Bezier<Scalar, 3> curve;
+        curve.set_control_points(control_pts);
+
+        SECTION("Single intersection")
+        {
+            std::array<Scalar, 4> plane{1, 1, 0, -1};
+
+            std::tie(t, converged) = intersect(curve, plane, 0., 10, 1e-3);
+            REQUIRE(converged);
+            REQUIRE(t == Approx(0.5).margin(1e-3));
+
+            std::tie(t, converged) = intersect(curve, plane, 1., 10, 1e-3);
+            REQUIRE(converged);
+            REQUIRE(t == Approx(0.5).margin(1e-3));
+
+            std::tie(t, converged) = intersect(curve, plane, 0.2, 10, 1e-3);
+            REQUIRE(converged);
+            REQUIRE(t == Approx(0.5).margin(1e-3));
+
+            std::tie(t, converged) = intersect(curve, plane, 0.9, 10, 1e-3);
+            REQUIRE(converged);
+            REQUIRE(t == Approx(0.5).margin(1e-3));
+        }
+
+        SECTION("Multiple intersections")
+        {
+            std::array<Scalar, 4> plane{-2, 1, 0, 0.5};
+            auto validate = [&](Scalar t) {
+                auto p = curve.evaluate(t);
+                REQUIRE(p[0] * plane[0] + p[1] * plane[1] + p[2] * plane[2] + plane[3] ==
+                        Approx(0).margin(1e-3));
+            };
+
+            Scalar t1, t2, t3, t4, t5, t6;
+
+            std::tie(t1, converged) = intersect(curve, plane, 0., 10, 1e-6);
+            REQUIRE(converged);
+            std::tie(t2, converged) = intersect(curve, plane, 0.1, 10, 1e-6);
+            REQUIRE(converged);
+            REQUIRE(t1 == Approx(t2).margin(1e-3));
+            validate(t1);
+            validate(t2);
+
+            std::tie(t3, converged) = intersect(curve, plane, 0.4, 10, 1e-6);
+            REQUIRE(converged);
+            std::tie(t4, converged) = intersect(curve, plane, 0.6, 10, 1e-6);
+            REQUIRE(converged);
+            REQUIRE(t3 == Approx(t4).margin(1e-3));
+            REQUIRE(t3 == Approx(0.5).margin(1e-3));
+            validate(t3);
+            validate(t4);
+
+            std::tie(t5, converged) = intersect(curve, plane, 0.9, 10, 1e-6);
+            REQUIRE(converged);
+            std::tie(t6, converged) = intersect(curve, plane, 1.0, 10, 1e-6);
+            REQUIRE(converged);
+            REQUIRE(t5 == Approx(t6).margin(1e-3));
+            validate(t5);
+            validate(t6);
+        }
+    }
+}
+
+TEST_CASE("Curve-in-patch-plane intersect", "[intersect]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    SECTION("Line plane")
+    {
+        Plane<Scalar, 3> patch;
+        patch.initialize();
+
+        std::array<Scalar, 4> plane{1, 1, 0, -1};
+
+        Scalar u, v;
+        bool converged;
+        std::tie(u, v, converged) = intersect(patch, 0., 0., 1., 1., plane, 0., 0., 10, 1e-3);
+        REQUIRE(converged);
+        REQUIRE(u == Approx(0.5).margin(1e-3));
+        REQUIRE(v == Approx(0.5).margin(1e-3));
+
+        std::tie(u, v, converged) = intersect(patch, 0., 0., 1., 0., plane, 0., 0., 10, 1e-3);
+        REQUIRE(converged);
+        REQUIRE(u == Approx(1).margin(1e-3));
+        REQUIRE(v == Approx(0).margin(1e-3));
+
+        std::tie(u, v, converged) = intersect(patch, 0., 0.1, 1., 0.1, plane, 0., 0., 10, 1e-3);
+        REQUIRE(converged);
+        REQUIRE(u == Approx(0.9).margin(1e-3));
+        REQUIRE(v == Approx(0.1).margin(1e-3));
+    }
+
+    SECTION("curve on cylinder")
+    {
+        Cylinder<Scalar, 3> patch;
+        Cylinder<Scalar, 3>::Frame frame;
+        frame << 0, 1, 0, 0, 0, 1, 1, 0, 0;
+        patch.set_frame(frame);
+        patch.initialize();
+
+        std::array<Scalar, 4> plane{1, 1, 0, -1};
+
+        auto validate = [&](auto u, auto v) {
+            auto p = patch.evaluate(u, v);
+            REQUIRE(p[0] * plane[0] + p[1] * plane[1] + p[2] * plane[2] + plane[3] ==
+                    Approx(0).margin(1e-3));
+        };
+
+        Scalar u, v;
+        bool converged;
+
+        SECTION("Straight line")
+        {
+            std::tie(u, v, converged) = intersect(patch, 0., 0., 0., 1., plane, 0., 0., 10, 1e-3);
+            REQUIRE(converged);
+            REQUIRE(u == Approx(0).margin(1e-3));
+            REQUIRE(v == Approx(0).margin(1e-3));
+            validate(u, v);
+        }
+
+        SECTION("Sprial")
+        {
+            std::tie(u, v, converged) =
+                intersect(patch, M_PI, 0., 0., 1., plane, M_PI / 2, 0.5, 10, 1e-3);
+            REQUIRE(converged);
+            validate(u, v);
+        }
+
+        SECTION("Arc")
+        {
+            std::tie(u, v, converged) =
+                intersect(patch, M_PI, 0.5, 0., 0.5, plane, M_PI / 2, 0.5, 10, 1e-3);
+            REQUIRE(converged);
+            validate(u, v);
+        }
+
+        SECTION("Tangent")
+        {
+            plane = {0, 1, 0, -1};
+            std::tie(u, v, converged) =
+                intersect(patch, M_PI, 0.5, 0., 0.5, plane, M_PI / 2, 0.5, 10, 1e-3);
+            REQUIRE(converged);
+            validate(u, v);
+        }
+
+        SECTION("Not intersecting")
+        {
+            plane = {0, 1, 0, -1.1};
+            std::tie(u, v, converged) =
+                intersect(patch, M_PI, 0.5, 0., 0.5, plane, M_PI / 2, 0.5, 10, 1e-3);
+            REQUIRE_FALSE(converged);
+        }
+
+        SECTION("Multple intersections")
+        {
+            plane = {0, 1, 0, -0.5};
+
+            std::tie(u, v, converged) =
+                intersect(patch, M_PI, 0., -M_PI, 1., plane, M_PI, 0.3, 20, 1e-3);
+            REQUIRE(converged);
+            validate(u, v);
+
+            Scalar u2, v2;
+            std::tie(u2, v2, converged) =
+                intersect(patch, M_PI, 0., -M_PI, 1., plane, -M_PI, 0.7, 20, 1e-3);
+            REQUIRE(converged);
+            validate(u2, v2);
+
+            REQUIRE(std::hypot(u - u2, v - v2) > 0.1);
+        }
+
+        SECTION("Degenerate line")
+        {
+            std::tie(u, v, converged) =
+                intersect(patch, 0., 0., 0., 0., plane, M_PI, 0.3, 20, 1e-3);
+            REQUIRE(converged);
+            validate(u, v);
+
+            std::tie(u, v, converged) =
+                intersect(patch, 0., 1., 0., 1., plane, M_PI, 0.3, 20, 1e-3);
+            REQUIRE_FALSE(converged);
+        }
+    }
+}
+
+TEST_CASE("Generic curve-in-patch-plane intersect", "[intersect]")
+{
+    using namespace nanospline;
+    using Scalar = double;
+
+    auto validate =
+        [](const auto& curve, const auto& patch, Scalar t, Scalar u, Scalar v, Scalar tol) {
+            auto p0 = curve.evaluate(t);
+            auto p1 = patch.evaluate(u, v);
+            REQUIRE((p0 - p1).norm() == Approx(0).margin(tol));
+        };
+
+    SECTION("Line plane")
+    {
+        Line<Scalar, 3> line;
+        line.set_location({0, 0, 0});
+        line.set_direction({1, 1, 1});
+        line.initialize();
+
+        Plane<Scalar, 3> plane;
+        Eigen::Matrix<Scalar, 2, 3> frame;
+        frame << 1, 0, 0, 0, 1, 0;
+        plane.set_location({0.0, 0.0, 0.5});
+        plane.set_frame(frame);
+        plane.initialize();
+
+        Scalar t, u, v;
+        bool converged;
+        std::tie(t, u, v, converged) = intersect(line, plane, 0., 0., 0., 10, 1e-3);
+        REQUIRE(converged);
+        validate(line, plane, t, u, v, 1e-3);
+    }
+
+    SECTION("Parallel line and plane")
+    {
+        Line<Scalar, 3> line;
+        line.set_location({0, 0, 0});
+        line.set_direction({1, 0, 0});
+        line.initialize();
+
+        Plane<Scalar, 3> plane;
+        Eigen::Matrix<Scalar, 2, 3> frame;
+        frame << 1, 0, 0, 0, 1, 0;
+        plane.set_location({0.0, 0.0, 0.5});
+        plane.set_frame(frame);
+        plane.initialize();
+
+        Scalar t, u, v;
+        bool converged;
+        std::tie(t, u, v, converged) = intersect(line, plane, 0., 0., 0., 10, 1e-3);
+        REQUIRE_FALSE(converged);
+    }
+
+    SECTION("Line Sphere")
+    {
+        Line<Scalar, 3> line;
+        line.set_location({0, 0, 0});
+        line.set_direction({1, 1, 1});
+        line.initialize();
+
+        Sphere<Scalar, 3> sphere;
+        sphere.set_location({0, 0, 0});
+        sphere.set_radius(1);
+        sphere.initialize();
+
+        Scalar t, u, v;
+        bool converged;
+        std::tie(t, u, v, converged) = intersect(line, sphere, 0.5, 0.5, 0.5, 10, 1e-3);
+        REQUIRE(converged);
+        validate(line, sphere, t, u, v, 1e-3);
+
+        std::tie(t, u, v, converged) = intersect(line, sphere, -0.5, M_PI + 0.5, -0.5, 10, 1e-3);
+        REQUIRE(converged);
+        validate(line, sphere, t, u, v, 1e-3);
+    }
+
+    SECTION("Curve plane")
+    {
+        Bezier<Scalar, 3> curve;
+        Eigen::Matrix<Scalar, 4, 3> control_points;
+        control_points << 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1;
+        curve.set_control_points(control_points);
+        curve.initialize();
+
+        Plane<Scalar, 3> plane;
+        plane.set_location({0.5, 0.5, 0.5});
+        Eigen::Matrix<Scalar, 2, 3> frame;
+        frame << 1, 0, 0, 0, 1, 0;
+        plane.set_frame(frame);
+        plane.initialize();
+
+        Scalar t, u, v;
+        bool converged;
+        std::tie(t, u, v, converged) = intersect(curve, plane, 0., 0., 0., 10, 1e-3);
+        validate(curve, plane, t, u, v, 1e-3);
+    }
+
+    SECTION("Curve patch")
+    {
+        Bezier<Scalar, 3> curve;
+        Eigen::Matrix<Scalar, 4, 3> control_points;
+        control_points << 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1;
+        curve.set_control_points(control_points);
+        curve.initialize();
+
+        BezierPatch<Scalar, 3, 3, 3> patch;
+        Eigen::Matrix<Scalar, 16, 3> control_grid;
+        control_grid << 0, 0, 1, 1, 0, 0, 2, 0, 1, 3, 0, 0, 0, 1, 0, 1, 1, 1, 2, 1, 0, 3, 1, 1, 0,
+            2, 1, 1, 2, 0, 2, 2, 1, 3, 2, 0, 0, 3, 0, 1, 3, 1, 2, 3, 0, 3, 3, 1;
+        patch.set_control_grid(control_grid);
+
+        Scalar t, u, v;
+        bool converged;
+        std::tie(t, u, v, converged) = intersect(curve, patch, 0., 0., 0., 10, 1e-3);
+        REQUIRE(converged);
+        validate(curve, patch, t, u, v, 1e-3);
+
+        std::tie(t, u, v, converged) = intersect(curve, patch, 0.9, 0.5, 0.5, 10, 1e-3);
+        REQUIRE(converged);
+        validate(curve, patch, t, u, v, 1e-3);
+    }
+}


### PR DESCRIPTION
### Summary:
* Add 3 forms of curve-patch intersection support.
* Add unit tests.

### Generic curve and generic patch

```c++
#include <nanospline/intersect.h>

Scalar t, u, v;
bool convergdd;

std::tie(t, u, v, converged) = nanospline::intersect(
    curve,           ///< Input curve.
    patch,           ///< Input patch.
    t0,              ///< Initial guess of the intersection on curve.
    u0, v0,          ///< Initial guess of the intersection on patch.
    num_iterations,  ///< Max num iterations.
    tolerance);      ///< Convergence tolerance.
```

### Generic curve and plane

```c++
#include <nanospline/intersect.h>

std::array<Scalar, 4> plane; // Coefficients of the plane equation.
                             // i.e. [a,b,c,d] -> ax + by + cz + d = 0.
Scalar t;
bool converged;

std::tie(t, converged) = nanospline::intersect(
    curve,          ///< Input curve.
    plane,          ///< Plane eqquation coefficients.
    t0,             ///< Initial guess of the intersection on curve.
    num_iterations, ///< Max num iterations.
    tolerance);     ///< Convergence tolerance.
```

### Embedded curve and plane
```c++
#include <nanospline/intersect.h>

std::array<Scalar, 4> plane; // Coefficients of the plane equation.
                             // i.e. [a,b,c,d] -> ax + by + cz + d = 0.
Scalar u, v;
bool converged;

std::tie(u, v, converged) = nanospline::intersect(
    patch,          ///< The patch that contains the curve.
    pu, pv,         ///< The uv coordinate of the starting point.
    qu, qv,         ///< The uv coordinate of the end point.
    plane,          ///< Plane eqquation coefficients.
    u0, v0,         ///< Initial guess of the intersection on curve.
    num_iterations, ///< Max num iterations.
    tolerance);     ///< Convergence tolerance.
```
